### PR TITLE
Fit to initial markers after render

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Simply add something similar to this to your styles:
 }
 ```
 
-In `config/environment.js` you can specify additional Google Map libraries
+In `config/environment.js` you can specify additional Google Maps libraries
 to be loaded along with this add-on (check the full list [here](https://developers.google.com/maps/documentation/javascript/libraries))
 and optional API key for your application (additional info could be found [here](https://developers.google.com/maps/web/)).
 
@@ -50,6 +50,18 @@ ENV['g-map'] = {
 {{/g-map}}
 ```
 
+## Map fits to show all initial Markers
+
+`shouldFit` attribute overrides `lat`, `lng`, `zoom` settings.
+
+```handlebars
+{{#g-map shouldFit=true}}
+  {{g-map-marker lat=37.7933 lng=-122.4167}}
+  {{g-map-marker lat=37.7833 lng=-122.4267}}
+  {{g-map-marker lat=37.7733 lng=-122.4067}}
+{{/g-map}}
+```
+
 ## Map with Markers and optional Info Windows
 
 Markers can have optional Info Windows activated on click.
@@ -58,6 +70,7 @@ in block form with `withInfowindow` flag set to `true`.
 
 ```handlebars
 {{#g-map lat=37.7833 lng=-122.4167 zoom=12}}
+  {{g-map-marker lat=37.7933 lng=-122.4167}}
   {{#g-map-marker lat=37.7833 lng=-122.4267 withInfowindow=true}}
     <h2>Infowindow header</h2>
     <p>Text with {{bound}} variables</p>
@@ -67,6 +80,8 @@ in block form with `withInfowindow` flag set to `true`.
 ```
 
 ## Map with route between 2 locations
+
+Using Google Maps [Directions](https://developers.google.com/maps/documentation/javascript/directions) service.
 
 ```handlebars
 {{#g-map lat=37.7833 lng=-122.4167 zoom=12}}

--- a/addon/components/g-map-marker.js
+++ b/addon/components/g-map-marker.js
@@ -16,6 +16,9 @@ export default Ember.Component.extend({
     let parent = this.get('parentView');
     assert('Must be inside {{#g-map}} component', parent instanceof GMapComponent);
 
+    let markers = parent.get('markers');
+    markers.push(this);
+
     if (isEmpty(this.get('withInfowindow'))) {
       this.set('withInfowindow', false);
     }

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -7,6 +7,11 @@ export default Ember.Component.extend({
   layout: layout,
   classNames: ['g-map'],
 
+  init() {
+    this._super();
+    this.markers = [];
+  },
+
   didInsertElement() {
     this._super();
     if (isEmpty(this.get('map'))) {
@@ -15,6 +20,9 @@ export default Ember.Component.extend({
     }
     this.setZoom();
     this.setCenter();
+    if (this.get('shouldFit')) {
+      this.fitToMarkers();
+    }
   },
 
   zoomChanged: observer('zoom', function() {
@@ -42,5 +50,17 @@ export default Ember.Component.extend({
       let center = new google.maps.LatLng(lat, lng);
       map.setCenter(center);
     }
+  },
+
+  fitToMarkers() {
+    let map = this.get('map');
+    let markers = this.get('markers');
+    let bounds = new google.maps.LatLngBounds();
+    let points = markers.map((marker) => {
+      return new google.maps.LatLng(marker.get('lat'), marker.get('lng'));
+    });
+
+    points.forEach((point) => bounds.extend(point));
+    map.fitBounds(bounds);
   }
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,6 +1,6 @@
 <h2 id="title">Ember-g-map Component</h2>
 
-{{#g-map lat=37.7833 lng=-122.4167 zoom=12}}
+{{#g-map shouldFit=true}}
   {{g-map-marker lat=37.7933 lng=-122.4167}}
   {{#g-map-marker lat=37.7733 lng=-122.4167 withInfowindow=true}}
     <h1>Pretty Infowindow!</h1>

--- a/tests/integration/components/g-map-test.js
+++ b/tests/integration/components/g-map-test.js
@@ -24,3 +24,18 @@ test('it renders', function(assert) {
 
   assert.equal(this.$().text().trim(), 'template block text');
 });
+
+test('it contains list of child markers', function(assert) {
+  assert.expect(1);
+
+  this.render(hbs`
+    {{#g-map}}
+      {{g-map-marker}}
+      {{g-map-marker}}
+      {{g-map-marker}}
+      {{g-map-marker}}
+    {{/g-map}}
+  `);
+
+  assert.equal(this.get('markers.length', 4));
+});

--- a/tests/unit/components/g-map-marker-test.js
+++ b/tests/unit/components/g-map-marker-test.js
@@ -275,3 +275,8 @@ test('new `Infowindow` shouldn\'t be constructed if no marker is set', function(
 
   google.maps.InfoWindow.restore();
 });
+
+test('it should register itself in parent\'s `markers` array on `init` event', function(assert) {
+  assert.equal(component.get('parentView.markers').length, 1);
+  assert.equal(component.get('parentView.markers')[0], component);
+});


### PR DESCRIPTION
- Every `g-map-marker` adds itself to 'markers' list on their parent `g-map` component.
- Main `g-map` component applies `fitBounds` of Google Maps API to fit to currently available markers. 