### PR TITLE
Marker registration refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,14 @@ ENV['g-map'] = {
 
 ## Map with Markers
 
+Mandatory `context` attribute ties child-elements
+with the main `g-map` component.
+
 ```handlebars
-{{#g-map lat=37.7833 lng=-122.4167 zoom=12}}
-  {{g-map-marker lat=37.7933 lng=-122.4167}}
-  {{g-map-marker lat=37.7833 lng=-122.4267}}
-  {{g-map-marker lat=37.7733 lng=-122.4067}}
+{{#g-map lat=37.7833 lng=-122.4167 zoom=12 as |context|}}
+  {{g-map-marker context lat=37.7933 lng=-122.4167}}
+  {{g-map-marker context lat=37.7833 lng=-122.4267}}
+  {{g-map-marker context lat=37.7733 lng=-122.4067}}
 {{/g-map}}
 ```
 
@@ -55,10 +58,10 @@ ENV['g-map'] = {
 `shouldFit` attribute overrides `lat`, `lng`, `zoom` settings.
 
 ```handlebars
-{{#g-map shouldFit=true}}
-  {{g-map-marker lat=37.7933 lng=-122.4167}}
-  {{g-map-marker lat=37.7833 lng=-122.4267}}
-  {{g-map-marker lat=37.7733 lng=-122.4067}}
+{{#g-map shouldFit=true as |context|}}
+  {{g-map-marker context lat=37.7933 lng=-122.4167}}
+  {{g-map-marker context lat=37.7833 lng=-122.4267}}
+  {{g-map-marker context lat=37.7733 lng=-122.4067}}
 {{/g-map}}
 ```
 
@@ -69,9 +72,9 @@ To provide content for Info Window you should call `g-map-marker`
 in block form with `withInfowindow` flag set to `true`.
 
 ```handlebars
-{{#g-map lat=37.7833 lng=-122.4167 zoom=12}}
-  {{g-map-marker lat=37.7933 lng=-122.4167}}
-  {{#g-map-marker lat=37.7833 lng=-122.4267 withInfowindow=true}}
+{{#g-map lat=37.7833 lng=-122.4167 zoom=12 as |context|}}
+  {{g-map-marker context lat=37.7933 lng=-122.4167}}
+  {{#g-map-marker context lat=37.7833 lng=-122.4267 withInfowindow=true}}
     <h2>Infowindow header</h2>
     <p>Text with {{bound}} variables</p>
     <button {{action "do"}}>Do</button>
@@ -84,8 +87,9 @@ in block form with `withInfowindow` flag set to `true`.
 Using Google Maps [Directions](https://developers.google.com/maps/documentation/javascript/directions) service.
 
 ```handlebars
-{{#g-map lat=37.7833 lng=-122.4167 zoom=12}}
-  {{g-map-route originLat=37.7933 originLng=-122.4167
+{{#g-map lat=37.7833 lng=-122.4167 zoom=12 as |context|}}
+  {{g-map-route context
+                originLat=37.7933 originLng=-122.4167
                 destinationLat=37.7733 destinationLng=-122.4167}}
 {{/g-map}}
 ```

--- a/addon/components/g-map-marker.js
+++ b/addon/components/g-map-marker.js
@@ -4,10 +4,9 @@ import GMapComponent from './g-map';
 
 const { isEmpty, isPresent, observer, computed, run, assert } = Ember;
 
-export default Ember.Component.extend({
+const GMapMarkerComponent = Ember.Component.extend({
   layout: layout,
   classNames: ['g-map-marker'],
-  positionalParams: ['mapContext'],
 
   map: computed.alias('mapContext.map'),
 
@@ -112,3 +111,9 @@ export default Ember.Component.extend({
     }
   }
 });
+
+GMapMarkerComponent.reopenClass({
+  positionalParams: ['mapContext']
+});
+
+export default GMapMarkerComponent;

--- a/addon/components/g-map-marker.js
+++ b/addon/components/g-map-marker.js
@@ -17,12 +17,10 @@ export default Ember.Component.extend({
     let mapContext = this.get('mapContext');
     assert('Must be inside {{#g-map}} component with context set', mapContext instanceof GMapComponent);
 
-    let markers = mapContext.get('markers');
-    markers.pushObject(this);
-
     if (isEmpty(this.get('withInfowindow'))) {
       this.set('withInfowindow', false);
     }
+    this.register();
   },
 
   didInsertElement() {
@@ -37,12 +35,23 @@ export default Ember.Component.extend({
   },
 
   willDestroyElement() {
+    this.unsetMarkerFromMap();
+    this.unregister();
+  },
+
+  register() {
+    this.get('mapContext').registerMarker(this);
+  },
+
+  unregister() {
+    this.get('mapContext').unregisterMarker(this);
+  },
+
+  unsetMarkerFromMap() {
     let marker = this.get('marker');
     if (isPresent(marker)) {
       marker.setMap(null);
     }
-    let markers = this.get('mapContext.markers');
-    markers.removeObject(this);
   },
 
   mapWasSet: observer('map', function() {

--- a/addon/components/g-map-marker.js
+++ b/addon/components/g-map-marker.js
@@ -7,17 +7,18 @@ const { isEmpty, isPresent, observer, computed, run, assert } = Ember;
 export default Ember.Component.extend({
   layout: layout,
   classNames: ['g-map-marker'],
+  positionalParams: ['mapContext'],
 
-  map: computed.alias('parentView.map'),
+  map: computed.alias('mapContext.map'),
 
   init() {
     this._super(arguments);
 
-    let parent = this.get('parentView');
-    assert('Must be inside {{#g-map}} component', parent instanceof GMapComponent);
+    let mapContext = this.get('mapContext');
+    assert('Must be inside {{#g-map}} component with context set', mapContext instanceof GMapComponent);
 
-    let markers = parent.get('markers');
-    markers.push(this);
+    let markers = mapContext.get('markers');
+    markers.pushObject(this);
 
     if (isEmpty(this.get('withInfowindow'))) {
       this.set('withInfowindow', false);
@@ -40,6 +41,8 @@ export default Ember.Component.extend({
     if (isPresent(marker)) {
       marker.setMap(null);
     }
+    let markers = this.get('mapContext.markers');
+    markers.removeObject(this);
   },
 
   mapWasSet: observer('map', function() {

--- a/addon/components/g-map-route.js
+++ b/addon/components/g-map-route.js
@@ -4,7 +4,7 @@ import GMapComponent from './g-map';
 
 const { isEmpty, isPresent, observer, computed, run, assert } = Ember;
 
-export default Ember.Component.extend({
+const GMapRouteComponent = Ember.Component.extend({
   layout: layout,
   classNames: ['g-map-marker'],
   positionalParams: ['mapContext'],
@@ -85,3 +85,9 @@ export default Ember.Component.extend({
     }
   }
 });
+
+GMapRouteComponent.reopenClass({
+  positionalParams: ['mapContext']
+});
+
+export default GMapRouteComponent;

--- a/addon/components/g-map-route.js
+++ b/addon/components/g-map-route.js
@@ -7,13 +7,14 @@ const { isEmpty, isPresent, observer, computed, run, assert } = Ember;
 export default Ember.Component.extend({
   layout: layout,
   classNames: ['g-map-marker'],
+  positionalParams: ['mapContext'],
 
-  map: computed.alias('parentView.map'),
+  map: computed.alias('mapContext.map'),
 
   init() {
     this._super(arguments);
-    let parent = this.get('parentView');
-    assert('Must be inside {{#g-map}} component', parent instanceof GMapComponent);
+    let mapContext = this.get('mapContext');
+    assert('Must be inside {{#g-map}} component with context set', mapContext instanceof GMapComponent);
   },
 
   didInsertElement() {

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -9,7 +9,7 @@ export default Ember.Component.extend({
 
   init() {
     this._super();
-    this.markers = [];
+    this.markers = Ember.A();
   },
 
   didInsertElement() {

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -52,6 +52,14 @@ export default Ember.Component.extend({
     }
   },
 
+  registerMarker(marker) {
+    this.get('markers').addObject(marker);
+  },
+
+  unregisterMarker(marker) {
+    this.get('markers').removeObject(marker);
+  },
+
   fitToMarkers() {
     let markers = this.get('markers').filter((marker) => {
       return isPresent(marker.get('lat')) && isPresent(marker.get('lng'));

--- a/addon/templates/components/g-map.hbs
+++ b/addon/templates/components/g-map.hbs
@@ -1,4 +1,4 @@
 <div class="g-map-canvas"></div>
 <div class="g-map-declarations">
-  {{yield}}
+  {{yield this}}
 </div>

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -1,8 +1,9 @@
 <h2 id="title">Ember-g-map Component</h2>
 
-{{#g-map shouldFit=true}}
-  {{g-map-marker lat=37.7933 lng=-122.4167}}
-  {{#g-map-marker lat=37.7733 lng=-122.4167 withInfowindow=true}}
+{{#g-map shouldFit=true as |context|}}
+  {{g-map-marker context lat=37.7933 lng=-122.4167}}
+
+  {{#g-map-marker context lat=37.7733 lng=-122.4167 withInfowindow=true}}
     <h1>Pretty Infowindow!</h1>
     <p>It can has bound variables:</p>
     <p>Random: {{randomVariable}}</p>
@@ -11,6 +12,7 @@
     <button {{action "refresh"}}>Refresh</button>
   {{/g-map-marker}}
 
-  {{g-map-route originLat=37.7933 originLng=-122.4167
+  {{g-map-route context
+                originLat=37.7933 originLng=-122.4167
                 destinationLat=37.7733 destinationLng=-122.4167}}
 {{/g-map}}

--- a/tests/integration/components/g-map-marker-test.js
+++ b/tests/integration/components/g-map-marker-test.js
@@ -12,8 +12,8 @@ test('it renders', function(assert) {
   // Handle any actions with this.on('myAction', function(val) { ... });
 
   this.render(hbs`
-    {{#g-map}}
-      {{g-map-marker}}
+    {{#g-map as |context|}}
+      {{g-map-marker context}}
     {{/g-map}}
   `);
 
@@ -21,8 +21,8 @@ test('it renders', function(assert) {
 
   // Template block usage:
   this.render(hbs`
-    {{#g-map}}
-      {{#g-map-marker}}
+    {{#g-map as |context|}}
+      {{#g-map-marker context}}
         template block text
       {{/g-map-marker}}
     {{/g-map}}

--- a/tests/integration/components/g-map-route-test.js
+++ b/tests/integration/components/g-map-route-test.js
@@ -12,8 +12,8 @@ test('it renders', function(assert) {
   // Handle any actions with this.on('myAction', function(val) { ... });
 
   this.render(hbs`
-    {{#g-map}}
-      {{g-map-route}}
+    {{#g-map as |context|}}
+      {{g-map-route context}}
     {{/g-map}}
   `);
 
@@ -21,8 +21,8 @@ test('it renders', function(assert) {
 
   // Template block usage:
   this.render(hbs`
-    {{#g-map}}
-      {{#g-map-route}}
+    {{#g-map as |context|}}
+      {{#g-map-route context}}
         template block text
       {{/g-map-route}}
     {{/g-map}}

--- a/tests/integration/components/g-map-test.js
+++ b/tests/integration/components/g-map-test.js
@@ -29,11 +29,11 @@ test('it contains list of child markers', function(assert) {
   assert.expect(1);
 
   this.render(hbs`
-    {{#g-map}}
-      {{g-map-marker}}
-      {{g-map-marker}}
-      {{g-map-marker}}
-      {{g-map-marker}}
+    {{#g-map as |context|}}
+      {{g-map-marker context}}
+      {{g-map-marker context}}
+      {{g-map-marker context}}
+      {{g-map-marker context}}
     {{/g-map}}
   `);
 

--- a/tests/unit/components/g-map-marker-test.js
+++ b/tests/unit/components/g-map-marker-test.js
@@ -31,7 +31,7 @@ moduleForComponent('g-map-marker', 'Unit | Component | g map marker', {
   }
 });
 
-test('it constructs new `Marker` object after render', function(assert) {
+test('it constructs new `Marker` object on `didInsertElement` event', function(assert) {
   component.trigger('didInsertElement');
   sinon.assert.calledOnce(google.maps.Marker);
   assert.equal(component.get('marker'), fakeMarkerObject);
@@ -44,28 +44,46 @@ test('new `Marker` isn\'t constructed if it already present in component', funct
 });
 
 test('it triggers `setMap` on `didInsertElement` event', function() {
-  component.setMap = sinon.spy();
+  component.setMap = sinon.stub();
   component.trigger('didInsertElement');
   sinon.assert.calledOnce(component.setMap);
 });
 
-test('it triggers `setMap` of marker with null on `willDestroyElement` event if marker is set', function() {
-  fakeMarkerObject.setMap = sinon.spy();
+test('it triggers `unsetMarkerFromMap` on `willDestroyElement` event', function() {
+  component.unsetMarkerFromMap = sinon.stub();
+  component.trigger('willDestroyElement');
+  sinon.assert.calledOnce(component.unsetMarkerFromMap);
+});
+
+test('it triggers `setMap` of marker with null during `unsetMarkerFromMap` if marker is set', function() {
+  fakeMarkerObject.setMap = sinon.stub();
 
   run(() => component.set('marker', fakeMarkerObject));
-  component.trigger('willDestroyElement');
+  run(() => component.unsetMarkerFromMap());
 
   sinon.assert.calledOnce(fakeMarkerObject.setMap);
   sinon.assert.calledWith(fakeMarkerObject.setMap, null);
 });
 
-test('it doesn\'t trigger `setMap` of marker on `willDestroyElement` event if there is no marker', function() {
-  fakeMarkerObject.setMap = sinon.spy();
+test('it doesn\'t trigger `setMap` of marker during `unsetMarkerFromMap` if there is no marker', function() {
+  fakeMarkerObject.setMap = sinon.stub();
 
   run(() => component.set('marker', undefined));
-  component.trigger('willDestroyElement');
+  run(() => component.unsetMarkerFromMap());
 
   sinon.assert.notCalled(fakeMarkerObject.setMap);
+});
+
+test('it triggers `register` on `init` event', function() {
+  component.register = sinon.stub();
+  component.trigger('init');
+  sinon.assert.calledOnce(component.register);
+});
+
+test('it triggers `unregister` on `willDestroyElement` event', function() {
+  component.unregister = sinon.stub();
+  component.trigger('willDestroyElement');
+  sinon.assert.calledOnce(component.unregister);
 });
 
 test('it triggers `setMap` on `mapContext.map` change', function() {
@@ -76,25 +94,25 @@ test('it triggers `setMap` on `mapContext.map` change', function() {
 });
 
 test('it triggers `setPosition` on `didInsertElement` event', function() {
-  component.setPosition = sinon.spy();
+  component.setPosition = sinon.stub();
   component.trigger('didInsertElement');
   sinon.assert.calledOnce(component.setPosition);
 });
 
 test('it triggers `setPosition` on `lat` change', function() {
-  component.setPosition = sinon.spy();
+  component.setPosition = sinon.stub();
   run(() => component.set('lat', 14));
   sinon.assert.calledOnce(component.setPosition);
 });
 
 test('it triggers `setPosition` on `lng` change', function() {
-  component.setPosition = sinon.spy();
+  component.setPosition = sinon.stub();
   run(() => component.set('lng', 21));
   sinon.assert.calledOnce(component.setPosition);
 });
 
 test('it triggers `setPosition` only once on `lat` and `lng` change', function() {
-  component.setPosition = sinon.spy();
+  component.setPosition = sinon.stub();
   run(() => component.setProperties({ lng: 1, lat: 11 }));
   sinon.assert.calledOnce(component.setPosition);
 });
@@ -164,13 +182,13 @@ test('it doesn\'t call `setMap` of google marker on `setMap` when no `map` prese
 });
 
 test('it triggers `setIcon` on `didInsertElement` event', function() {
-  component.setIcon = sinon.spy();
+  component.setIcon = sinon.stub();
   component.trigger('didInsertElement');
   sinon.assert.calledOnce(component.setIcon);
 });
 
 test('it triggers `setIcon` on `icon` change', function() {
-  component.setIcon = sinon.spy();
+  component.setIcon = sinon.stub();
   run(() => component.set('icon', 'image-src'));
   sinon.assert.calledOnce(component.setIcon);
 });
@@ -267,13 +285,25 @@ test('new `Infowindow` isn\'t constructed if no marker is set', function() {
   google.maps.InfoWindow.restore();
 });
 
-test('it registers itself in parent\'s `markers` array on `init` event', function(assert) {
-  assert.equal(component.get('mapContext.markers').length, 1);
-  assert.equal(component.get('mapContext.markers')[0], component);
+test('it registers itself in parent\'s `markers` array on `init` event', function() {
+  let mapContext;
+  run(() => mapContext = component.get('mapContext'));
+  mapContext.registerMarker = sinon.stub();
+
+  component.trigger('init');
+
+  sinon.assert.calledOnce(mapContext.registerMarker);
+  sinon.assert.calledWith(mapContext.registerMarker, component);
 });
 
-test('it unregisters itself in parent\'s `markers` array on `willDestroyElement` event', function(assert) {
-  assert.equal(component.get('mapContext.markers').length, 1);
+test('it unregisters itself in parent\'s `markers` array on `willDestroyElement` event', function() {
+  let unregisterStub = sinon.stub();
+  run(() => component.set('mapContext', {
+    unregisterMarker: unregisterStub
+  }));
+
   component.trigger('willDestroyElement');
-  assert.equal(component.get('mapContext.markers').length, 0);
+
+  sinon.assert.calledOnce(unregisterStub);
+  sinon.assert.calledWith(unregisterStub, component);
 });

--- a/tests/unit/components/g-map-marker-test.js
+++ b/tests/unit/components/g-map-marker-test.js
@@ -22,7 +22,7 @@ moduleForComponent('g-map-marker', 'Unit | Component | g map marker', {
   beforeEach() {
     sinon.stub(google.maps, 'Marker').returns(fakeMarkerObject);
     component = this.subject({
-      parentView: new GMapComponent()
+      mapContext: new GMapComponent()
     });
   },
 
@@ -68,10 +68,10 @@ test('it doesn\'t trigger `setMap` of marker on `willDestroyElement` event if th
   sinon.assert.notCalled(fakeMarkerObject.setMap);
 });
 
-test('it triggers `setMap` on `parentView.map` change', function() {
-  run(() => component.set('parentView', { map: '' }));
+test('it triggers `setMap` on `mapContext.map` change', function() {
+  run(() => component.set('mapContext', { map: '' }));
   component.setMap = sinon.spy();
-  run(() => component.set('parentView.map', {}));
+  run(() => component.set('mapContext.map', {}));
   sinon.assert.calledOnce(component.setMap);
 });
 
@@ -268,6 +268,12 @@ test('new `Infowindow` isn\'t constructed if no marker is set', function() {
 });
 
 test('it registers itself in parent\'s `markers` array on `init` event', function(assert) {
-  assert.equal(component.get('parentView.markers').length, 1);
-  assert.equal(component.get('parentView.markers')[0], component);
+  assert.equal(component.get('mapContext.markers').length, 1);
+  assert.equal(component.get('mapContext.markers')[0], component);
+});
+
+test('it unregisters itself in parent\'s `markers` array on `willDestroyElement` event', function(assert) {
+  assert.equal(component.get('mapContext.markers').length, 1);
+  component.trigger('willDestroyElement');
+  assert.equal(component.get('mapContext.markers').length, 0);
 });

--- a/tests/unit/components/g-map-route-test.js
+++ b/tests/unit/components/g-map-route-test.js
@@ -25,7 +25,7 @@ moduleForComponent('g-map-route', 'Unit | Component | g map route', {
     sinon.stub(google.maps, 'DirectionsRenderer').returns(fakeDirectionsRenderer);
     sinon.stub(google.maps, 'DirectionsService').returns(fakeDirectionsService);
     component = this.subject({
-      parentView: new GMapComponent()
+      mapContext: new GMapComponent()
     });
   },
 
@@ -92,10 +92,10 @@ test('new `DirectionsService` and `DirectionsRenderer` isn\'t being constructed 
   sinon.assert.notCalled(google.maps.DirectionsRenderer);
 });
 
-test('it triggers `initDirectionsService` on `parentView.map` change', function() {
-  run(() => component.set('parentView', { map: '' }));
+test('it triggers `initDirectionsService` on `mapContext.map` change', function() {
+  run(() => component.set('mapContext', { map: '' }));
   component.initDirectionsService = sinon.spy();
-  run(() => component.set('parentView.map', {}));
+  run(() => component.set('mapContext.map', {}));
   sinon.assert.calledOnce(component.initDirectionsService);
 });
 

--- a/tests/unit/components/g-map-test.js
+++ b/tests/unit/components/g-map-test.js
@@ -216,3 +216,28 @@ test('it calls `fitBounds` of google map on `fitToMarkers`', function() {
   google.maps.LatLng.restore();
   google.maps.LatLngBounds.restore();
 });
+
+test('it registers marker in `markers` array during `registerMarker`', function(assert) {
+  let component = this.subject();
+  this.render();
+
+  run(() => component.get('markers').addObject('first'));
+  run(() => component.registerMarker('second'));
+  run(() => component.registerMarker('third'));
+
+  assert.equal(component.get('markers').length, 3);
+  assert.equal(component.get('markers')[1], 'second');
+  assert.equal(component.get('markers')[2], 'third');
+});
+
+test('it unregisters marker from `markers` array during `unregisterMarker`', function(assert) {
+  let component = this.subject();
+  this.render();
+
+  run(() => component.get('markers').addObjects(['first', 'second', 'third']));
+  run(() => component.unregisterMarker('second'));
+
+  assert.equal(component.get('markers').length, 2);
+  assert.equal(component.get('markers')[0], 'first');
+  assert.equal(component.get('markers')[1], 'third');
+});


### PR DESCRIPTION
Registration of markers is now made via positional param `mapContext`. 
It allows to use markers/routes nested inside of any custom component rendered inside of global `g-map` component.
