### PR TITLE
keep the map fit to markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ has been closed by user.
 `markersFitMode` attribute overrides `lat`, `lng`, `zoom` settings.
 `markersFitMode` value can be one of:
 * 'init' - which will make the map fit the markers on creation.
-* 'live' - which will keep the map keep fitting the markers as they are added or
-removed.
+* 'live' - which will keep the map keep fitting the markers as they are added,
+removed or moved.
 
 ```handlebars
 {{#g-map markersFitMode='live' as |context|}}

--- a/README.md
+++ b/README.md
@@ -91,6 +91,10 @@ has been closed by user.
 ## Map fits to show all initial Markers
 
 `markersFitMode` attribute overrides `lat`, `lng`, `zoom` settings.
+`markersFitMode` value can be one of:
+* 'init' - which will make the map fit the markers on creation.
+* 'live' - which will keep the map keep fitting the markers as they are added or
+removed.
 
 ```handlebars
 {{#g-map markersFitMode='live' as |context|}}

--- a/README.md
+++ b/README.md
@@ -90,10 +90,10 @@ has been closed by user.
 
 ## Map fits to show all initial Markers
 
-`shouldFit` attribute overrides `lat`, `lng`, `zoom` settings.
+`markersFitMode` attribute overrides `lat`, `lng`, `zoom` settings.
 
 ```handlebars
-{{#g-map shouldFit=true as |context|}}
+{{#g-map markersFitMode='live' as |context|}}
   {{g-map-marker context lat=37.7933 lng=-122.4167}}
   {{g-map-marker context lat=37.7833 lng=-122.4267}}
   {{g-map-marker context lat=37.7733 lng=-122.4067}}

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -86,8 +86,14 @@ export default Ember.Component.extend({
     this.get('markers').removeObject(marker);
   },
 
+  shouldFit: computed('markersFitMode', function() {
+    return ['init', 'live'].indexOf(this.get('markersFitMode')) >= 0;
+  }),
+
   markersChanged: observer('markers.[]', function() {
-    run.once(this, 'fitToMarkers');
+    if (this.get('markersFitMode') === 'live') {
+      run.once(this, 'fitToMarkers');
+    }
   }),
 
   fitToMarkers() {

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -10,7 +10,7 @@ export default Ember.Component.extend({
 
   init() {
     this._super();
-    this.markers = Ember.A();
+    this.set('markers', Ember.A());
     if (isEmpty(this.get('options'))) {
       this.set('options', {});
     }
@@ -36,9 +36,7 @@ export default Ember.Component.extend({
     }
     this.setZoom();
     this.setCenter();
-    if (this.get('shouldFit')) {
-      this.fitToMarkers();
-    }
+    this.fitToMarkers();
   },
 
   permittedOptionsChanged: observer('permittedOptions', function() {
@@ -88,7 +86,15 @@ export default Ember.Component.extend({
     this.get('markers').removeObject(marker);
   },
 
+  markersChanged: observer('markers.[]', function() {
+    run.once(this, 'fitToMarkers');
+  }),
+
   fitToMarkers() {
+    if (!this.get('shouldFit')) {
+      return;
+    };
+
     const markers = this.get('markers').filter((marker) => {
       return isPresent(marker.get('lat')) && isPresent(marker.get('lng'));
     });

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -36,7 +36,9 @@ export default Ember.Component.extend({
     }
     this.setZoom();
     this.setCenter();
-    this.fitToMarkers();
+    if (this.get('shouldFit')) {
+      this.fitToMarkers();
+    }
   },
 
   permittedOptionsChanged: observer('permittedOptions', function() {
@@ -87,20 +89,16 @@ export default Ember.Component.extend({
   },
 
   shouldFit: computed('markersFitMode', function() {
-    return ['init', 'live'].indexOf(this.get('markersFitMode')) >= 0;
+    return Ember.A(['init', 'live']).contains(this.get('markersFitMode'));
   }),
 
-  markersChanged: observer('markers.[]', function() {
+  markersChanged: observer('markers.@each.lat', 'markers.@each.lng', function() {
     if (this.get('markersFitMode') === 'live') {
       run.once(this, 'fitToMarkers');
     }
   }),
 
   fitToMarkers() {
-    if (!this.get('shouldFit')) {
-      return;
-    };
-
     const markers = this.get('markers').filter((marker) => {
       return isPresent(marker.get('lat')) && isPresent(marker.get('lng'));
     });

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "ember-export-application-global": "^1.0.3",
     "ember-sinon": "0.3.0",
     "ember-sinon-qunit": "1.0.0",
-    "ember-suave": "1.2.0",
+    "ember-suave": "1.2.3",
     "ember-try": "0.0.8"
   },
   "keywords": [

--- a/tests/unit/components/g-map-test.js
+++ b/tests/unit/components/g-map-test.js
@@ -201,8 +201,26 @@ test('it doesn\'t call `setCenter` of google map on `setCenter` when no lng pres
   sinon.assert.notCalled(fakeMapObject.setCenter);
 });
 
-test('it calls `fitToMarkers` object on `didInsertElement`', function() {
+test('it calls `fitToMarkers` object on `didInsertElement` if shouldFit is set to true', function() {
   const component = this.subject({ shouldFit: true });
+  this.render();
+
+  component.fitToMarkers = sinon.stub();
+  component.trigger('didInsertElement');
+  sinon.assert.calledOnce(component.fitToMarkers);
+});
+
+test('it calls `fitToMarkers` object on `didInsertElement` if markersFitMode is "init"', function() {
+  const component = this.subject({ markersFitMode: 'init' });
+  this.render();
+
+  component.fitToMarkers = sinon.stub();
+  component.trigger('didInsertElement');
+  sinon.assert.calledOnce(component.fitToMarkers);
+});
+
+test('it calls `fitToMarkers` object on `didInsertElement` if markersFitMode is "live"', function() {
+  const component = this.subject({ markersFitMode: 'live' });
   this.render();
 
   component.fitToMarkers = sinon.stub();
@@ -216,6 +234,55 @@ test('it doesn\'t call `fitToMarkers` object on `didInsertElement` if shouldFit 
 
   component.fitToMarkers = sinon.stub();
   component.trigger('didInsertElement');
+  sinon.assert.notCalled(component.fitToMarkers);
+});
+
+test('it doesn\'t call `fitToMarkers` object on `didInsertElement` if markersFitMode has unexpected value', function() {
+  const component = this.subject({ markersFitMode: 'random-value' });
+  this.render();
+
+  component.fitToMarkers = sinon.stub();
+  component.trigger('didInsertElement');
+  sinon.assert.notCalled(component.fitToMarkers);
+});
+
+test('it triggers `fitToMarkers` on new marker added with markersFitMode set to "live"', function() {
+  const firstMarker = Ember.Object.create({ lat: 1, lng: 2 });
+  const secondMarker = Ember.Object.create({ lat: 3, lng: 4 });
+  const component = this.subject({ markersFitMode: 'live' });
+  this.render();
+
+  run(() => component.get('markers').addObject(firstMarker));
+  component.fitToMarkers = sinon.spy();
+  run(() => component.get('markers').addObject(secondMarker));
+  sinon.assert.calledOnce(component.fitToMarkers);
+});
+
+test('it triggers `fitToMarkers` only once on `lat`/`lng` change of markers with markersFitMode set to "live"', function() {
+  const firstMarker = Ember.Object.create({ lat: 1, lng: 2 });
+  const secondMarker = Ember.Object.create({ lat: 3, lng: 4 });
+  const component = this.subject({ markersFitMode: 'live' });
+  this.render();
+
+  run(() => component.get('markers').addObjects([firstMarker, secondMarker]));
+  component.fitToMarkers = sinon.spy();
+  run(() => {
+    firstMarker.setProperties({ lng: 4, lat: 5 });
+    secondMarker.setProperties({ lng: 6, lat: 7 });
+  });
+  sinon.assert.calledOnce(component.fitToMarkers);
+});
+
+test('it doesn\'t trigger `fitToMarkers` with markersFitMode !== "live"', function() {
+  const firstMarker = Ember.Object.create({ lat: 1, lng: 2 });
+  const secondMarker = Ember.Object.create({ lat: 3, lng: 4 });
+  const component = this.subject({ markersFitMode: 'init' });
+  this.render();
+
+  run(() => component.get('markers').addObject(firstMarker));
+  component.fitToMarkers = sinon.spy();
+  run(() => firstMarker.setProperties({ lng: 4, lat: 5 }));
+  run(() => component.get('markers').addObject(secondMarker));
   sinon.assert.notCalled(component.fitToMarkers);
 });
 
@@ -259,25 +326,33 @@ test('it registers marker in `markers` array during `registerMarker`', function(
   const component = this.subject();
   this.render();
 
-  run(() => component.get('markers').addObject('first'));
-  run(() => component.registerMarker('second'));
-  run(() => component.registerMarker('third'));
+  const firstMarker = { name: 'first' };
+  const secondMarker = { name: 'second' };
+  const thirdMarker = { name: 'third' };
+
+  run(() => component.get('markers').addObject(firstMarker));
+  run(() => component.registerMarker(secondMarker));
+  run(() => component.registerMarker(thirdMarker));
 
   assert.equal(component.get('markers').length, 3);
-  assert.equal(component.get('markers')[1], 'second');
-  assert.equal(component.get('markers')[2], 'third');
+  assert.equal(component.get('markers')[1], secondMarker);
+  assert.equal(component.get('markers')[2], thirdMarker);
 });
 
 test('it unregisters marker from `markers` array during `unregisterMarker`', function(assert) {
   const component = this.subject();
   this.render();
 
-  run(() => component.get('markers').addObjects(['first', 'second', 'third']));
-  run(() => component.unregisterMarker('second'));
+  const firstMarker = { name: 'first' };
+  const secondMarker = { name: 'second' };
+  const thirdMarker = { name: 'third' };
+
+  run(() => component.get('markers').addObjects([firstMarker, secondMarker, thirdMarker]));
+  run(() => component.unregisterMarker(secondMarker));
 
   assert.equal(component.get('markers').length, 2);
-  assert.equal(component.get('markers')[0], 'first');
-  assert.equal(component.get('markers')[1], 'third');
+  assert.equal(component.get('markers')[0], firstMarker);
+  assert.equal(component.get('markers')[1], thirdMarker);
 });
 
 test('it calls `closeInfowindow` for each marker in group on `groupMarkerClicked`', function() {


### PR DESCRIPTION
I had to make this small change to keep the map fit to markers while they change.
My use-case is a filtered list of people shown as markers on the map.. so I want the map to always show all markers.
I could maybe make this functionality togglable with an option flag like 'shouldKeepFitToMarkers'...