### PR TITLE
Clustering support using markerclustererplus

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -3,7 +3,8 @@
     "document",
     "window",
     "-Promise",
-    "google"
+    "google",
+    "MarkerClusterer"
   ],
   "browser": true,
   "boss": true,

--- a/addon/components/g-map-cluster-marker.js
+++ b/addon/components/g-map-cluster-marker.js
@@ -6,6 +6,7 @@ const { isPresent, computed, assert } = Ember;
 
 const GMapClusterMarkerComponent =  GMapMarkerComponent.extend({
   mapContext: computed.alias('clustererContext.mapContext'),
+  clusterer: computed.alias('clustererContext.clusterer'),
 
   init() {
     this._super(arguments);
@@ -17,7 +18,7 @@ const GMapClusterMarkerComponent =  GMapMarkerComponent.extend({
 
   unsetMarkerFromMap() {
     const marker = this.get('marker');
-    const clusterer = this.get('clustererContext.clusterer');
+    const clusterer = this.get('clusterer');
 
     if (isPresent(marker) && isPresent(clusterer)) {
       clusterer.removeMarker(marker);
@@ -25,7 +26,7 @@ const GMapClusterMarkerComponent =  GMapMarkerComponent.extend({
   },
 
   setMap() {
-    const clusterer = this.get('clustererContext.clusterer');
+    const clusterer = this.get('clusterer');
     const marker = this.get('marker');
 
     if (isPresent(marker) && isPresent(clusterer)) {

--- a/addon/components/g-map-cluster-marker.js
+++ b/addon/components/g-map-cluster-marker.js
@@ -1,0 +1,41 @@
+import Ember from 'ember';
+import GMapClusterer from './g-map-clusterer';
+import GMapMarkerComponent from './g-map-marker';
+
+const { isPresent, computed, assert } = Ember;
+
+const GMapClusterMarkerComponent =  GMapMarkerComponent.extend({
+  mapContext: computed.alias('clustererContext.mapContext'),
+
+  init() {
+    this._super(arguments);
+
+    const clustererContext = this.get('clustererContext');
+    assert('Must be inside {{#g-map-clusterer}} component with context set',
+      clustererContext instanceof GMapClusterer);
+  },
+
+  unsetMarkerFromMap() {
+    const marker = this.get('marker');
+    const clusterer = this.get('clustererContext.clusterer');
+
+    if (isPresent(marker) && isPresent(clusterer)) {
+      clusterer.removeMarker(marker);
+    }
+  },
+
+  setMap() {
+    const clusterer = this.get('clustererContext.clusterer');
+    const marker = this.get('marker');
+
+    if (isPresent(marker) && isPresent(clusterer)) {
+      clusterer.addMarker(marker);
+    }
+  }
+});
+
+GMapClusterMarkerComponent.reopenClass({
+  positionalParams: ['clustererContext']
+});
+
+export default GMapClusterMarkerComponent;

--- a/addon/components/g-map-clusterer.js
+++ b/addon/components/g-map-clusterer.js
@@ -1,0 +1,60 @@
+import Ember from 'ember';
+import layout from '../templates/components/g-map-clusterer';
+import GMapComponent from './g-map';
+
+const { isEmpty, isPresent, computed, observer, run, assert } = Ember;
+
+const GMapClustererComponent = Ember.Component.extend({
+  layout: layout,
+  classNames: ['g-map-clusterer'],
+
+  map: computed.oneWay('mapContext.map'),
+  markers: computed.oneWay('mapContext.markers'),
+
+  init() {
+    this._super(arguments);
+
+    const mapContext = this.get('mapContext');
+    assert('Must be inside {{#g-map}} component with context set', mapContext instanceof GMapComponent);
+
+    if (isEmpty(this.get('options'))) {
+      this.set('options', {});
+    }
+  },
+
+  mapWasSet: observer('map', function() {
+    const map = this.get('map');
+    const clusterer = this.get('clusterer');
+
+    if (isPresent(map) && isEmpty(clusterer)) {
+      const options = this.get('options');
+      this.set('clusterer', new MarkerClusterer(map, [], options));
+    }
+  }),
+
+  willDestroyElement() {
+    const clusterer = this.get('clusterer');
+
+    if (isPresent(clusterer)) {
+      clusterer.clearMarkers();
+    }
+  },
+
+  markersChanged: observer('markers.@each.lat', 'markers.@each.lng', function() {
+    run.once(this, 'repaintClusterer');
+  }),
+
+  repaintClusterer() {
+    const clusterer = this.get('clusterer');
+
+    if (isPresent(clusterer)) {
+      clusterer.repaint();
+    }
+  }
+});
+
+GMapClustererComponent.reopenClass({
+  positionalParams: ['mapContext']
+});
+
+export default GMapClustererComponent;

--- a/addon/components/g-map-clusterer.js
+++ b/addon/components/g-map-clusterer.js
@@ -7,6 +7,7 @@ const { isEmpty, isPresent, computed, observer, run, assert, typeOf } = Ember;
 const GMapClustererComponent = Ember.Component.extend({
   layout: layout,
   classNames: ['g-map-clusterer'],
+  supportedEvents: ['clusteringstart', 'clusteringend'],
 
   map: computed.oneWay('mapContext.map'),
   markers: computed.oneWay('mapContext.markers'),
@@ -33,10 +34,8 @@ const GMapClustererComponent = Ember.Component.extend({
     }
   }),
 
-  events: ['clusteringstart', 'clusteringend'],
-
   attachEvents() {
-    const events = this.get('events');
+    const events = this.get('supportedEvents');
 
     for (let i = 0; i < events.length; i++) {
       const event = events[i];
@@ -60,7 +59,7 @@ const GMapClustererComponent = Ember.Component.extend({
 
   detachEvents() {
     const clusterer = this.get('clusterer');
-    const events = this.get('events');
+    const events = this.get('supportedEvents');
 
     for (let i = 0; i < events.length; i++) {
       google.maps.event.clearListeners(clusterer, events[i]);

--- a/addon/templates/components/g-map-clusterer.hbs
+++ b/addon/templates/components/g-map-clusterer.hbs
@@ -1,0 +1,1 @@
+{{yield this}}

--- a/app/components/g-map-cluster-marker.js
+++ b/app/components/g-map-cluster-marker.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-g-map/components/g-map-cluster-marker';

--- a/app/components/g-map-clusterer.js
+++ b/app/components/g-map-clusterer.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-g-map/components/g-map-clusterer';

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/ember-g-map/index.js
+++ b/blueprints/ember-g-map/index.js
@@ -1,0 +1,9 @@
+module.exports = {
+  normalizeEntityName: function() {},
+
+  afterInstall: function() {
+    return this.addBowerPackageToProject([
+      { name: 'markerclustererplus', target: '~2.1.4' }
+    ]);
+  }
+};

--- a/blueprints/ember-g-map/index.js
+++ b/blueprints/ember-g-map/index.js
@@ -2,8 +2,6 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    return this.addBowerPackageToProject([
-      { name: 'markerclustererplus', target: '~2.1.4' }
-    ]);
+    return this.addBowerPackageToProject('markerclustererplus', '~2.1.4');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -11,7 +11,8 @@
     "jquery": "^2.1.4",
     "loader.js": "ember-cli/loader.js#3.2.1",
     "qunit": "~1.18.0",
-    "sinonjs": "~1.17.1"
+    "sinonjs": "~1.17.1",
+    "markerclustererplus": "~2.1.4"
   },
   "devDependencies": {
     "blanket": "~1.1.5"

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -4,6 +4,9 @@ var EmberApp = require('ember-cli/lib/broccoli/ember-addon');
 module.exports = function(defaults) {
   var app = new EmberApp(defaults, {
     // Add options here
+    gMap: {
+      extensions: ['clustering']
+    }
   });
 
   /*

--- a/index.js
+++ b/index.js
@@ -7,6 +7,8 @@ module.exports = {
   included: function(app, parentAddon) {
     var target = (parentAddon || app);
     target.import('vendor/addons.css');
+
+    app.import(app.bowerDirectory + '/markerclustererplus/src/markerclusterer.js');
   },
 
   contentFor: function(type, config) {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,14 @@ module.exports = {
     var target = (parentAddon || app);
     target.import('vendor/addons.css');
 
-    app.import(app.bowerDirectory + '/markerclustererplus/src/markerclusterer.js');
+    var gMapOptions = target.options.gMap || {};
+    var extensions = gMapOptions.extensions || [];
+    for (let i = 0; i < extensions.length; i++) {
+      let extension = extensions[i];
+      if (extension === 'clustering') {
+        app.import(app.bowerDirectory + '/markerclustererplus/src/markerclusterer.js');
+      }
+    }
   },
 
   contentFor: function(type, config) {

--- a/index.js
+++ b/index.js
@@ -10,8 +10,8 @@ module.exports = {
 
     var gMapOptions = target.options.gMap || {};
     var extensions = gMapOptions.extensions || [];
-    for (let i = 0; i < extensions.length; i++) {
-      let extension = extensions[i];
+    for (var i = 0; i < extensions.length; i++) {
+      var extension = extensions[i];
       if (extension === 'clustering') {
         app.import(app.bowerDirectory + '/markerclustererplus/src/markerclusterer.js');
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-g-map",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "An ember-cli addon for integration with google maps.",
   "directories": {
     "doc": "doc",

--- a/tests/integration/components/g-map-cluster-marker-test.js
+++ b/tests/integration/components/g-map-cluster-marker-test.js
@@ -1,0 +1,36 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('g-map-cluster-marker', 'Integration | Component | g map cluster marker', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`
+    {{#g-map as |context|}}
+      {{#g-map-clusterer context as |clustererContext|}}
+        {{g-map-cluster-marker clustererContext}}
+      {{/g-map-clusterer}}
+    {{/g-map}}
+  `);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#g-map as |context|}}
+      {{#g-map-clusterer context as |clustererContext|}}
+        {{#g-map-cluster-marker clustererContext}}
+          template block text
+        {{/g-map-cluster-marker}}
+      {{/g-map-clusterer}}
+    {{/g-map}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});

--- a/tests/integration/components/g-map-clusterer-test.js
+++ b/tests/integration/components/g-map-clusterer-test.js
@@ -1,0 +1,32 @@
+import { moduleForComponent, test } from 'ember-qunit';
+import hbs from 'htmlbars-inline-precompile';
+
+moduleForComponent('g-map-clusterer', 'Integration | Component | g map clusterer', {
+  integration: true
+});
+
+test('it renders', function(assert) {
+  assert.expect(2);
+
+  // Set any properties with this.set('myProperty', 'value');
+  // Handle any actions with this.on('myAction', function(val) { ... });
+
+  this.render(hbs`
+    {{#g-map as |context|}}
+      {{g-map-clusterer context}}
+    {{/g-map}}
+  `);
+
+  assert.equal(this.$().text().trim(), '');
+
+  // Template block usage:
+  this.render(hbs`
+    {{#g-map as |context|}}
+      {{#g-map-clusterer context}}
+        template block text
+      {{/g-map-clusterer}}
+    {{/g-map}}
+  `);
+
+  assert.equal(this.$().text().trim(), 'template block text');
+});


### PR DESCRIPTION
#### Changes

I tried to follow your coding style without changing your components and made the following additions to support clustering:
- A `g-map-clusterer` component is added. It should be used inside a `g-map` component with context set, just like the markers. You can set the `options` param to customize the clusterer ([available options](https://google-maps-utility-library-v3.googlecode.com/svn/trunk/markerclustererplus/docs/reference.html#MarkerClustererOptions)). The clusterer also supports the `live` mode and repaints itself when the markers change.
- A `g-map-cluster-marker` component is added. It extends the `g-map-marker` component and should be used inside a `g-map-clusterer` component with context set.
- A default blueprint is added and the index.js changed to import the clustering library dependency.
#### Usage

```
{{#g-map as |context|}}
  {{#g-map-clusterer context as |clustererContext|}}
    {{g-map-cluster-marker clustererContext}}
  {{/g-map-clusterer}}
{{/g-map}}
```

You can also mix clustered markers with default markers without issues (i hope) like the example below:

```
{{#g-map as |context|}}

  {{#g-map-clusterer context as |clustererContext|}}
    {{g-map-cluster-marker clustererContext}}
  {{/g-map-clusterer}}

  {{g-map-marker context}}

{{/g-map}}
```
### Todo
- More tests?
- Documentation
- I think i should make the import of the clustering lib optional using `ENV['g-map']` 
