### PR TITLE
Custom open/close Info Window events

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,13 +117,23 @@ Markers can have bound Info Windows activated on click.
 To properly bind Info Window with Marker you should call `g-map-marker`
 in block form and set context of Info Window to the one provided by Marker.
 
+You can optionally setup custom `openOn`/`closeOn` events for each Info Window,
+available options are: `click`, `dblclick`, `rightclick`, `mouseover`, `mouseout`.
+By default `openOn` is set to `click` and `closeOn` is set to `null`. When `openOn`
+and `closeOn` are the same, Info Window visibility is being toggled by this event.
+
 ```handlebars
 {{#g-map lat=37.7833 lng=-122.4167 zoom=12 as |context|}}
-  {{g-map-marker context lat=37.7933 lng=-122.4167}}
   {{#g-map-marker context lat=37.7833 lng=-122.4267 as |markerContext|}}
-    {{#g-map-infowindow markerContext}}
+    {{#g-map-infowindow markerContext openOn="mouseover" closeOn="mouseout"}}
       <h2>Bound Info Window</h2>
     {{/g-map-infowindow}}
+  {{/g-map-marker}}
+  {{#g-map-marker context lat=37.7833 lng=-122.4267 as |markerContext|}}
+    {{g-map-infowindow markerContext openOn="click" closeOn="click" title="Blockless form 1"}}
+  {{/g-map-marker}}
+  {{#g-map-marker context lat=37.7833 lng=-122.4267 as |markerContext|}}
+    {{g-map-infowindow markerContext openOn="dblclick" title="Blockless form 2"}}
   {{/g-map-marker}}
 {{/g-map}}
 ```

--- a/addon/components/g-map-infowindow.js
+++ b/addon/components/g-map-infowindow.js
@@ -91,16 +91,14 @@ const GMapInfowindowComponent = Ember.Component.extend({
 
   open() {
     const infowindow = this.get('infowindow');
-    if (isPresent(infowindow)) {
-      const map = this.get('map');
-      const marker = this.get('marker');
+    const map = this.get('map');
+    const marker = this.get('marker');
 
-      this.set('isOpen', true);
-      if (isPresent(map) && isPresent(marker)) {
-        infowindow.open(map, marker);
-      } else if (isPresent(map)) {
-        infowindow.open(map);
-      }
+    this.set('isOpen', true);
+    if (isPresent(map) && isPresent(marker)) {
+      infowindow.open(map, marker);
+    } else if (isPresent(map)) {
+      infowindow.open(map);
     }
   },
 

--- a/addon/components/g-map-marker.js
+++ b/addon/components/g-map-marker.js
@@ -74,13 +74,15 @@ const GMapMarkerComponent = Ember.Component.extend({
   },
 
   attachTogglingInfowindowEvent(marker, infowindow, event) {
-    marker.addListener(event, () => {
-      if (infowindow.get('isOpen')) {
-        infowindow.close();
-      } else {
-        infowindow.open();
-      }
-    });
+    if (isPresent(event)) {
+      marker.addListener(event, () => {
+        if (infowindow.get('isOpen')) {
+          infowindow.close();
+        } else {
+          infowindow.open();
+        }
+      });
+    }
   },
 
   unsetMarkerFromMap() {

--- a/addon/components/g-map-marker.js
+++ b/addon/components/g-map-marker.js
@@ -42,12 +42,45 @@ const GMapMarkerComponent = Ember.Component.extend({
     this.get('mapContext').unregisterMarker(this);
   },
 
-  registerInfowindow(infowindow) {
+  registerInfowindow(infowindow, openEvent, closeEvent) {
     this.set('infowindow', infowindow);
+    this.attachOpenCloseEvents(infowindow, openEvent, closeEvent);
   },
 
   unregisterInfowindow() {
     this.set('infowindow', null);
+  },
+
+  attachOpenCloseEvents(infowindow, openEvent, closeEvent) {
+    const marker = this.get('marker');
+    if (openEvent === closeEvent) {
+      this.attachTogglingInfowindowEvent(marker, infowindow, openEvent);
+    } else {
+      this.attachOpenInfowindowEvent(marker, infowindow, openEvent);
+      this.attachCloseInfowindowEvent(marker, infowindow, closeEvent);
+    }
+  },
+
+  attachOpenInfowindowEvent(marker, infowindow, event) {
+    if (isPresent(event)) {
+      marker.addListener(event, () => infowindow.open());
+    }
+  },
+
+  attachCloseInfowindowEvent(marker, infowindow, event) {
+    if (isPresent(event)) {
+      marker.addListener(event, () => infowindow.close());
+    }
+  },
+
+  attachTogglingInfowindowEvent(marker, infowindow, event) {
+    marker.addListener(event, () => {
+      if (infowindow.get('isOpen')) {
+        infowindow.close();
+      } else {
+        infowindow.open();
+      }
+    });
   },
 
   unsetMarkerFromMap() {

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -26,7 +26,7 @@
   {{/g-map-marker}}
 
   {{#g-map-address-marker context address=addressQuery as |markerContext|}}
-    {{#g-map-infowindow markerContext}}
+    {{#g-map-infowindow markerContext openEvent="mouseover" closeEvent="mouseout"}}
       <h1>Bound to Address Query</h1>
     {{/g-map-infowindow}}
   {{/g-map-address-marker}}

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -26,7 +26,7 @@
   {{/g-map-marker}}
 
   {{#g-map-address-marker context address=addressQuery as |markerContext|}}
-    {{#g-map-infowindow markerContext openEvent="mouseover" closeEvent="mouseout"}}
+    {{#g-map-infowindow markerContext openOn="mouseover" closeOn="mouseout"}}
       <h1>Bound to Address Query</h1>
     {{/g-map-infowindow}}
   {{/g-map-address-marker}}

--- a/tests/unit/components/g-map-infowindow-test.js
+++ b/tests/unit/components/g-map-infowindow-test.js
@@ -23,9 +23,12 @@ moduleForComponent('g-map-infowindow', 'Unit | Component | g map infowindow', {
       addListener: sinon.stub()
     };
     sinon.stub(google.maps, 'InfoWindow').returns(fakeInfowindowObject);
-    component = this.subject({
-      mapContext: new GMapComponent()
-    });
+
+    const mapContext = new GMapComponent();
+    mapContext.registerInfowindow = sinon.stub();
+    mapContext.unregisterInfowindow = sinon.stub();
+
+    component = this.subject({ mapContext });
   },
 
   afterEach() {
@@ -85,6 +88,7 @@ test('it triggers `unregisterInfowindow` on `willDestroyElement` event', functio
   run(() => component.set('hasMarker', true));
 
   mapContext.unregisterInfowindow = sinon.stub();
+  component.close = sinon.stub();
   component.trigger('willDestroyElement');
 
   sinon.assert.calledOnce(mapContext.unregisterInfowindow);
@@ -98,47 +102,43 @@ test('it constructs new `InfoWindow` object during `buildInfowindow`', function(
   assert.equal(returnedInfowindow, fakeInfowindowObject);
 });
 
-test('it triggers `attachCloseEvent` during `buildInfowindow` if onClose attr specified', function() {
+test('it triggers `addListener` of infowindow during `buildInfowindow` if onClose attr specified', function() {
   run(() => component.set('attrs', { onClose: 'action' }));
-
-  component.attachCloseEvent = sinon.stub();
   run(() => component.buildInfowindow());
 
-  sinon.assert.calledOnce(component.attachCloseEvent);
-  sinon.assert.calledWith(component.attachCloseEvent, fakeInfowindowObject);
-});
-
-test('it doesn\'t triggers `attachCloseEvent` during `buildInfowindow` if onClose isn\'t specified', function() {
-  run(() => component.set('attrs', { onClose: undefined }));
-
-  component.attachCloseEvent = sinon.stub();
-  run(() => component.buildInfowindow());
-
-  sinon.assert.notCalled(component.attachCloseEvent);
-});
-
-test('it triggers `addListener` of InfoWindow during `attachCloseEvent`', function() {
-  run(() => component.attachCloseEvent(fakeInfowindowObject));
   sinon.assert.calledOnce(fakeInfowindowObject.addListener);
   sinon.assert.calledWith(fakeInfowindowObject.addListener, 'closeclick');
 });
 
-test('it sends action `onClose` on callback for `closeclick` event', function() {
+test('it doesn\'t trigger `addListener` during `buildInfowindow` if onClose isn\'t specified', function() {
+  run(() => component.set('attrs', { onClose: undefined }));
+  run(() => component.buildInfowindow());
+  sinon.assert.notCalled(fakeInfowindowObject.addListener);
+});
+
+test('it triggers `handleCloseClickEvent` on callback for `closeclick` event', function() {
   fakeInfowindowObject.addListener.callsArg(1);
+  component.handleCloseClickEvent = sinon.stub();
+
+  run(() => component.set('attrs', { onClose: 'action' }));
+  run(() => component.buildInfowindow());
+
+  sinon.assert.calledOnce(component.handleCloseClickEvent);
+});
+
+test('it sends action `onClose` on `handleCloseClickEvent`', function() {
   component.sendAction = sinon.stub();
 
   run(() => component.set('attrs', { onClose: 'action' }));
-  run(() => component.attachCloseEvent(fakeInfowindowObject));
+  run(() => component.handleCloseClickEvent());
 
   sinon.assert.calledOnce(component.sendAction);
   sinon.assert.calledWith(component.sendAction, 'onClose');
 });
 
-test('it runs closure action `attrs.onClose` directly on callback for `closeclick` event', function() {
-  fakeInfowindowObject.addListener.callsArg(1);
-
+test('it runs closure action `attrs.onClose` directly on `handleCloseClickEvent`', function() {
   run(() => component.set('attrs', { onClose: sinon.stub() }));
-  run(() => component.attachCloseEvent(fakeInfowindowObject));
+  run(() => component.handleCloseClickEvent());
 
   sinon.assert.calledOnce(component.attrs.onClose);
 });
@@ -305,29 +305,62 @@ test('it doesn\'t call `setPosition` of InfoWindow on `setPosition` when no lng 
   sinon.assert.notCalled(fakeInfowindowObject.setPosition);
 });
 
-test('it calls `open` of InfoWindow on `setMap` with `map` present', function() {
+test('it calls `open` on `setMap` when `hasMarker` is false', function() {
+  run(() => component.set('hasMarker', false));
+
+  component.open = sinon.stub();
+  run(() => component.setMap());
+
+  sinon.assert.calledOnce(component.open);
+});
+
+test('it doesn\'t call `open` on `setMap` when `hasMarker` is true', function() {
+  run(() => component.set('hasMarker', true));
+
+  component.open = sinon.stub();
+  run(() => component.setMap());
+
+  sinon.assert.notCalled(component.open);
+});
+
+test('it calls `open` of InfoWindow on `open` with single arg when only `map` is present', function() {
   const mapObject = {};
   run(() => component.setProperties({
     map: mapObject,
-    hasMarker: false,
+    marker: undefined,
     infowindow: fakeInfowindowObject
   }));
 
   fakeInfowindowObject.open = sinon.stub();
-
-  run(() => component.setMap());
+  run(() => component.open());
 
   sinon.assert.calledOnce(fakeInfowindowObject.open);
   sinon.assert.calledWith(fakeInfowindowObject.open, mapObject);
 });
 
-test('it doesn\'t call `open` of InfoWindow on `setMap` when no `map` present', function() {
-  fakeInfowindowObject.setMap = sinon.stub();
+test('it calls `open` of InfoWindow on `open` with 2 args when `map` and `marker` are present', function() {
+  const mapObject = { mapParam: 'value' };
+  const markerObject = { markerParam: 'value' };
   run(() => component.setProperties({
-    hasMarker: false,
+    map: mapObject,
+    marker: markerObject,
     infowindow: fakeInfowindowObject
   }));
-  run(() => component.setMap());
+
+  fakeInfowindowObject.open = sinon.stub();
+  run(() => component.open());
+
+  sinon.assert.calledOnce(fakeInfowindowObject.open);
+  sinon.assert.calledWith(fakeInfowindowObject.open, mapObject, markerObject);
+});
+
+test('it doesn\'t call `open` of InfoWindow on `open` when no `map` present', function() {
+  fakeInfowindowObject.setMap = sinon.stub();
+  run(() => component.setProperties({
+    map: undefined,
+    infowindow: fakeInfowindowObject
+  }));
+  run(() => component.open());
   sinon.assert.notCalled(fakeInfowindowObject.setMap);
 });
 
@@ -344,34 +377,24 @@ test('it doesn\'t call `open` of InfoWindow on `setMap` when `hasMarker` is true
   sinon.assert.notCalled(fakeInfowindowObject.setMap);
 });
 
-test(`it calls 'addListener' of google marker and 'registerInfowindow' of marker context
+test(`it calls 'registerInfowindow' of marker context
       on 'setMarker' with 'map' and 'marker' present`, function() {
   const mapObject = {};
-  const fakeMarkerObject = { addListener: sinon.stub() };
+  const markerObject = {};
 
   let mapContext;
   run(() => mapContext = component.get('mapContext'));
-  mapContext.registerInfowindow = sinon.stub();
-
   run(() => component.setProperties({
     map: mapObject,
-    marker: fakeMarkerObject,
+    marker: markerObject,
     infowindow: fakeInfowindowObject
   }));
 
   mapContext.registerInfowindow = sinon.stub();
-  fakeMarkerObject.addListener = sinon.stub().callsArg(1);
-  fakeInfowindowObject.open = sinon.stub();
   run(() => component.setMarker());
 
   sinon.assert.calledOnce(mapContext.registerInfowindow);
   sinon.assert.calledWith(mapContext.registerInfowindow, component);
-
-  sinon.assert.calledOnce(fakeMarkerObject.addListener);
-  sinon.assert.calledWith(fakeMarkerObject.addListener, 'click');
-
-  sinon.assert.calledOnce(fakeInfowindowObject.open);
-  sinon.assert.calledWith(fakeInfowindowObject.open, mapObject, fakeMarkerObject);
 });
 
 test('it doesn\'t call `addListener` of google marker on `setMarker` when no `map` present', function() {

--- a/tests/unit/components/g-map-infowindow-test.js
+++ b/tests/unit/components/g-map-infowindow-test.js
@@ -377,7 +377,7 @@ test('it doesn\'t call `open` of InfoWindow on `setMap` when `hasMarker` is true
   sinon.assert.notCalled(fakeInfowindowObject.setMap);
 });
 
-test(`it calls 'registerInfowindow' of marker context
+test(`it calls 'retrieveOpenEvent', 'retrieveCloseEvent' and 'registerInfowindow' of marker context
       on 'setMarker' with 'map' and 'marker' present`, function() {
   const mapObject = {};
   const markerObject = {};
@@ -390,11 +390,76 @@ test(`it calls 'registerInfowindow' of marker context
     infowindow: fakeInfowindowObject
   }));
 
+  component.retrieveOpenEvent = sinon.stub().returns('open');
+  component.retrieveCloseEvent = sinon.stub().returns('close');
   mapContext.registerInfowindow = sinon.stub();
   run(() => component.setMarker());
 
+  sinon.assert.calledOnce(component.retrieveOpenEvent);
+  sinon.assert.calledOnce(component.retrieveCloseEvent);
+
   sinon.assert.calledOnce(mapContext.registerInfowindow);
-  sinon.assert.calledWith(mapContext.registerInfowindow, component);
+  sinon.assert.calledWith(mapContext.registerInfowindow, component, 'open', 'close');
+});
+
+test('`retrieveOpenEvent` returns `openOn` event if it\'s whitelisted in const', function(assert) {
+  let resultingEvent;
+  run(() => component.set('openOn', 'click'));
+  run(() => resultingEvent = component.retrieveOpenEvent());
+  assert.equal(resultingEvent, 'click');
+
+  run(() => component.set('openOn', 'dblclick'));
+  run(() => resultingEvent = component.retrieveOpenEvent());
+  assert.equal(resultingEvent, 'dblclick');
+
+  run(() => component.set('openOn', 'rightclick'));
+  run(() => resultingEvent = component.retrieveOpenEvent());
+  assert.equal(resultingEvent, 'rightclick');
+
+  run(() => component.set('openOn', 'mouseover'));
+  run(() => resultingEvent = component.retrieveOpenEvent());
+  assert.equal(resultingEvent, 'mouseover');
+
+  run(() => component.set('openOn', 'mouseout'));
+  run(() => resultingEvent = component.retrieveOpenEvent());
+  assert.equal(resultingEvent, 'mouseout');
+});
+
+test('`retrieveCloseEvent` returns `closeOn` event if it\'s whitelisted in const', function(assert) {
+  let resultingEvent;
+  run(() => component.set('closeOn', 'click'));
+  run(() => resultingEvent = component.retrieveCloseEvent());
+  assert.equal(resultingEvent, 'click');
+
+  run(() => component.set('closeOn', 'dblclick'));
+  run(() => resultingEvent = component.retrieveCloseEvent());
+  assert.equal(resultingEvent, 'dblclick');
+
+  run(() => component.set('closeOn', 'rightclick'));
+  run(() => resultingEvent = component.retrieveCloseEvent());
+  assert.equal(resultingEvent, 'rightclick');
+
+  run(() => component.set('closeOn', 'mouseover'));
+  run(() => resultingEvent = component.retrieveCloseEvent());
+  assert.equal(resultingEvent, 'mouseover');
+
+  run(() => component.set('closeOn', 'mouseout'));
+  run(() => resultingEvent = component.retrieveCloseEvent());
+  assert.equal(resultingEvent, 'mouseout');
+});
+
+test('`retrieveOpenEvent` returns `click` event if `openOn` isn\'t whitelisted in const', function(assert) {
+  let resultingEvent;
+  run(() => component.set('openOn', 'wrong-event'));
+  run(() => resultingEvent = component.retrieveOpenEvent());
+  assert.equal(resultingEvent, 'click');
+});
+
+test('`retrieveCloseEvent` returns `null` event if `closeOn` isn\'t whitelisted in const', function(assert) {
+  let resultingEvent;
+  run(() => component.set('closeOn', 'wrong-event'));
+  run(() => resultingEvent = component.retrieveCloseEvent());
+  assert.equal(resultingEvent, null);
 });
 
 test('it doesn\'t call `addListener` of google marker on `setMarker` when no `map` present', function() {


### PR DESCRIPTION
Following request from https://github.com/asennikov/ember-g-map/issues/19:
* options to set custom open/close events for Info Windows attached to Markers;
* if open and close window is the same (e.g. 'click'), then Info Window visibility is being toggled by this event;
* available events: `click`, `dblclick`, `rightclick`, `mouseover`, `mouseout`;
* default behaviour is to show Info Window on "click" on Marker and hide only by click on close button on Info Window.

Here are some examples:

```
{{#g-map-address-marker context address=addressQuery as |markerContext|}}
  {{#g-map-infowindow markerContext openOn="mouseover" closeOn="mouseout"}}
    ...
  {{/g-map-infowindow}}
{{/g-map-address-marker}}

{{#g-map-marker context lat=lat lng=lng as |markerContext|}}
  {{#g-map-infowindow markerContext openOn="click" closeOn="click"}}
    ...
  {{/g-map-infowindow}}
{{/g-map-address-marker}}

{{#g-map-marker context lat=lat lng=lng as |markerContext|}}
  {{#g-map-infowindow markerContext openOn="dblclick"}}
    ...
  {{/g-map-infowindow}}
{{/g-map-address-marker}}
```