### PR TITLE
Polyline options for Routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,21 @@ You can optionally set travel mode with `travelMode` attr:
 - `transit`
 - `driving` (default)
 
+You can optionally set following custom polyline options as attributes:
+- `strokeColor`
+- `strokeWeight`
+- `strokeOpacity`
+- `zIndex`
+
 ```handlebars
 {{#g-map lat=37.7833 lng=-122.4167 zoom=12 as |context|}}
   {{g-map-route context
+                travelMode='driving' strokeColor='red'
+                originLat=37.7933 originLng=-122.4167
+                destinationLat=37.7733 destinationLng=-122.4167}}
+
+  {{g-map-route context
+                travelMode='bicycling' strokeColor='blue' zIndex=10
                 originLat=37.7933 originLng=-122.4167
                 destinationLat=37.7733 destinationLng=-122.4167}}
 {{/g-map}}

--- a/addon/components/g-map-infowindow.js
+++ b/addon/components/g-map-infowindow.js
@@ -2,8 +2,11 @@ import Ember from 'ember';
 import layout from '../templates/components/g-map-infowindow';
 import GMapComponent from './g-map';
 import GMapMarkerComponent from './g-map-marker';
+import compact from '../utils/compact';
 
 const { isEmpty, isPresent, observer, computed, run, assert, typeOf } = Ember;
+
+const allowedOptions = Ember.A(['disableAutoPan', 'maxWidth', 'pixelOffset']);
 
 const OPEN_CLOSE_EVENTS = Ember.A(
   [ 'click', 'dblclick', 'rightclick', 'mouseover', 'mouseout' ]
@@ -48,24 +51,16 @@ const GMapInfowindowComponent = Ember.Component.extend({
     }
   },
 
-  optionsChanged: observer('disableAutoPan', 'maxWidth', 'pixelOffset', function() {
+  optionsChanged: observer(...allowedOptions, function() {
     run.once(this, 'setOptions');
   }),
 
   setOptions() {
     const infowindow = this.get('infowindow');
-    const options = ['disableAutoPan', 'maxWidth', 'pixelOffset'];
-    const infoWindowOptions = {};
+    const options = compact(this.getProperties(allowedOptions));
 
-    for (let i = 0; i < options.length; i++) {
-      const value = this.get(options[i]);
-      if (isPresent(value)) {
-        infoWindowOptions[options[i]] = value;
-      }
-    }
-
-    if (isPresent(infowindow) && Object.keys(infoWindowOptions).length !== 0) {
-      infowindow.setOptions(infoWindowOptions);
+    if (isPresent(infowindow) && isPresent(Object.keys(options))) {
+      infowindow.setOptions(options);
     }
   },
 

--- a/addon/components/g-map-route.js
+++ b/addon/components/g-map-route.js
@@ -1,8 +1,11 @@
 import Ember from 'ember';
 import layout from '../templates/components/g-map-route';
 import GMapComponent from './g-map';
+import compact from '../utils/compact';
 
 const { isEmpty, isPresent, observer, computed, run, assert } = Ember;
+
+const allowedPolylineOptions = Ember.A(['strokeColor', 'strokeWeight', 'strokeOpacity', 'zIndex']);
 
 const TRAVEL_MODES = {
   walking: google.maps.TravelMode.WALKING,
@@ -58,6 +61,7 @@ const GMapRouteComponent = Ember.Component.extend({
       this.set('directionsService', service);
 
       this.updateRoute();
+      this.updatePolylineOptions();
     }
   },
 
@@ -65,7 +69,7 @@ const GMapRouteComponent = Ember.Component.extend({
     run.once(this, 'updateRoute');
   }),
 
-  updateRoute: function() {
+  updateRoute() {
     const service = this.get('directionsService');
     const renderer = this.get('directionsRenderer');
     const originLat = this.get('originLat');
@@ -90,6 +94,24 @@ const GMapRouteComponent = Ember.Component.extend({
           renderer.setDirections(response);
         }
       });
+    }
+  },
+
+  polylineOptionsChanged: observer(...allowedPolylineOptions, function() {
+    run.once(this, 'updatePolylineOptions');
+  }),
+
+  updatePolylineOptions() {
+    const renderer = this.get('directionsRenderer');
+    const polylineOptions = compact(this.getProperties(allowedPolylineOptions));
+
+    if (isPresent(renderer) && isPresent(Object.keys(polylineOptions))) {
+      renderer.setOptions({ polylineOptions });
+
+      const directions = renderer.getDirections();
+      if (isPresent(directions)) {
+        renderer.setDirections(directions);
+      }
     }
   },
 

--- a/addon/templates/components/g-map-address-route.hbs
+++ b/addon/templates/components/g-map-address-route.hbs
@@ -1,1 +1,4 @@
-{{g-map-route mapContext originLat=originLat originLng=originLng destinationLat=destinationLat destinationLng=destinationLng}}
+{{g-map-route mapContext zIndex=zIndex
+              strokeColor=strokeColor strokeWeight=strokeWeight strokeOpacity=strokeOpacity
+              originLat=originLat originLng=originLng
+              destinationLat=destinationLat destinationLng=destinationLng}}

--- a/addon/utils/compact.js
+++ b/addon/utils/compact.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default function(objectInstance) {
+  const compactedObject = {};
+
+  for (let key in objectInstance) {
+    const value = objectInstance[key];
+
+    if (Ember.isPresent(value)) {
+      compactedObject[key] = value;
+    }
+  }
+
+  return compactedObject;
+}

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -7,6 +7,7 @@ export default Ember.Controller.extend({
 
   addressQuery: 'SF, Lafayette Park',
   addressQueryInput: computed.reads('addressQuery'),
+  routeColor: 'red',
 
   customOptions: {
     mapTypeId: google.maps.MapTypeId.TERRAIN
@@ -23,6 +24,14 @@ export default Ember.Controller.extend({
 
     updateAdressQuery() {
       this.set('addressQuery', this.get('addressQueryInput'));
+    },
+
+    toggleRouteColor() {
+      if (this.get('routeColor') === 'red') {
+        this.set('routeColor', 'green');
+      } else {
+        this.set('routeColor', 'red');
+      }
     }
   }
 });

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -8,6 +8,9 @@
   <p>
     <button type="submit"> Update bound marker </button>
   </p>
+  <p>
+    <button {{action "toggleRouteColor"}}> Toggle route color </button>
+  </p>
 </form>
 
 {{#g-map markersFitMode="live" options=customOptions as |context|}}
@@ -39,7 +42,7 @@
   {{g-map-infowindow context title="Blockless Infowindow" message="Contains plain text"
                      lat=37.7633 lng=-122.4367 onClose=(action "onInfowindowClosed")}}
 
-  {{g-map-route context
+  {{g-map-route context strokeColor=routeColor strokeWeight=2 strokeOpacity=0.5 zIndex=10
                 originLat=37.7933 originLng=-122.4467
                 destinationLat=37.7433 destinationLng=-122.3867}}
 

--- a/tests/unit/components/g-map-route-test.js
+++ b/tests/unit/components/g-map-route-test.js
@@ -20,8 +20,10 @@ moduleForComponent('g-map-route', 'Unit | Component | g map route', {
       route: sinon.stub()
     };
     fakeDirectionsRenderer = {
+      getDirections: sinon.stub(),
       setDirections: sinon.stub(),
-      setMap: sinon.stub()
+      setMap: sinon.stub(),
+      setOptions: sinon.stub()
     };
     sinon.stub(google.maps, 'DirectionsRenderer').returns(fakeDirectionsRenderer);
     sinon.stub(google.maps, 'DirectionsService').returns(fakeDirectionsService);
@@ -201,4 +203,92 @@ test('it calls `setDirections` of directionsRenderer on `updateRoute`', function
 
   google.maps.LatLng.restore();
   fakeDirectionsService.route = sinon.stub();
+});
+
+test('it triggers `updatePolylineOptions` on `initDirectionsService` call', function() {
+  component.updatePolylineOptions = sinon.spy();
+
+  run(() => component.set('map', {}));
+  run(() => component.initDirectionsService());
+
+  sinon.assert.calledOnce(component.updatePolylineOptions);
+});
+
+test('it triggers `updatePolylineOptions` on `strokeColor` change', function() {
+  component.updatePolylineOptions = sinon.spy();
+  run(() => component.set('strokeColor', '#000000'));
+  sinon.assert.calledOnce(component.updatePolylineOptions);
+});
+
+test('it triggers `updatePolylineOptions` on `strokeWeight` change', function() {
+  component.updatePolylineOptions = sinon.spy();
+  run(() => component.set('strokeWeight', 5));
+  sinon.assert.calledOnce(component.updatePolylineOptions);
+});
+
+test('it triggers `updatePolylineOptions` on `strokeOpacity` change', function() {
+  component.updatePolylineOptions = sinon.spy();
+  run(() => component.set('strokeOpacity', 0.1));
+  sinon.assert.calledOnce(component.updatePolylineOptions);
+});
+
+test('it triggers `updatePolylineOptions` on `zIndex` change', function() {
+  component.updatePolylineOptions = sinon.spy();
+  run(() => component.set('zIndex', 2));
+  sinon.assert.calledOnce(component.updatePolylineOptions);
+});
+
+test('it triggers `updatePolylineOptions` only once on several option changes', function() {
+  component.updatePolylineOptions = sinon.spy();
+  run(() => component.setProperties({
+    strokeWeight: 2,
+    strokeOpacity: 0.5,
+    zIndex: 4
+  }));
+  sinon.assert.calledOnce(component.updatePolylineOptions);
+});
+
+test('it calls `setOptions` of directionsRenderer on `updatePolylineOptions`', function() {
+  const polylineOptions = {
+    strokeColor: '#ffffff',
+    strokeWeight: 2,
+    strokeOpacity: 1,
+    zIndex: 1
+  };
+  run(() => component.setProperties(polylineOptions));
+  run(() => component.set('directionsRenderer', fakeDirectionsRenderer));
+
+  run(() => component.updatePolylineOptions());
+
+  sinon.assert.calledOnce(fakeDirectionsRenderer.setOptions);
+  sinon.assert.calledWith(fakeDirectionsRenderer.setOptions, { polylineOptions });
+});
+
+test('it doesn\'t call `setOptions` of directionsRenderer on `updatePolylineOptions` if no options are provided', function() {
+  run(() => component.set('directionsRenderer', fakeDirectionsRenderer));
+  run(() => component.updatePolylineOptions());
+  sinon.assert.notCalled(fakeDirectionsRenderer.setOptions);
+});
+
+test('it calls `setDirections` of directionsRenderer on `updatePolylineOptions` if `getDirections` return something', function() {
+  fakeDirectionsRenderer.getDirections.returns(['a', 'b']);
+
+  run(() => component.set('strokeColor', '#ffffff'));
+  run(() => component.set('directionsRenderer', fakeDirectionsRenderer));
+
+  run(() => component.updatePolylineOptions());
+
+  sinon.assert.calledOnce(fakeDirectionsRenderer.setDirections);
+  sinon.assert.calledWith(fakeDirectionsRenderer.setDirections, ['a', 'b']);
+});
+
+test('it doesn\'t call `setDirections` of directionsRenderer on `updatePolylineOptions` if `getDirections` return nothing', function() {
+  fakeDirectionsRenderer.getDirections.returns([]);
+
+  run(() => component.set('strokeColor', '#ffffff'));
+  run(() => component.set('directionsRenderer', fakeDirectionsRenderer));
+
+  run(() => component.updatePolylineOptions());
+
+  sinon.assert.notCalled(fakeDirectionsRenderer.setDirections);
 });

--- a/tests/unit/utils/compact-test.js
+++ b/tests/unit/utils/compact-test.js
@@ -1,0 +1,21 @@
+import compact from 'ember-g-map/utils/compact';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | compact');
+
+test('compact returns an object with empty elements removed', function(assert) {
+  const object = {
+    a: '1',
+    b: 2,
+    c: undefined,
+    'abc': null,
+    key: ''
+  };
+  const expectedResult = {
+    a: '1',
+    b: 2
+  };
+
+  const result = compact(object);
+  assert.deepEqual(result, expectedResult, 'it does not contain empty elements');
+});


### PR DESCRIPTION
Some better styling for polylines produced by {{g-map-route}} and {{g-map-address-route}} components.
Available options:
* strokeColor
* strokeWeight
* strokeOpacity
* zIndex

![image](https://cloud.githubusercontent.com/assets/1835550/13884267/51ceda2e-ed3e-11e5-9709-8812a7ff7b58.png)