### PR TITLE
removing protocol relative url

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ module.exports = {
     var content = '';
 
     if (type === 'head') {
-      var src = "//maps.googleapis.com/maps/api/js";
+      var src = "https://maps.googleapis.com/maps/api/js";
       var gMapConfig = config['g-map'] || {};
       var params = [];
 


### PR DESCRIPTION
This small change fixes the protocol relative url so that it can work using ember-cli-cordova 

http://www.paulirish.com/2010/the-protocol-relative-url/

I have tested this and it works in a cordova app