### PR TITLE
Add new config options for Google Maps API script

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,11 @@ In `config/environment.js` you can specify:
 
 ```javascript
 ENV['g-map'] = {
+  exclude: true,
   libraries: ['places', 'geometry'],
   key: 'your-unique-google-map-api-key',
+  client: 'gme-your-unique-google-client-id',
+  version: '3.26',
   language: 'ru',
   protocol: 'https'
 }

--- a/index.js
+++ b/index.js
@@ -21,6 +21,19 @@ module.exports = {
       if (key) {
         params.push('key=' + encodeURIComponent(key));
       }
+      
+      var version = gMapConfig.version;
+      if (version) {
+        params.push('v=' + encodeURIComponent(version));
+      }
+      
+      var client = gMapConfig.client;
+      if (client) {
+        params.push('client=' + encodeURIComponent(client));
+        if (!version) {
+          params.push('v=3');
+        }
+      }
 
       var libraries = gMapConfig.libraries;
       if (libraries && libraries.length) {
@@ -39,6 +52,11 @@ module.exports = {
 
       src += '?' + params.join('&');
       content = '<script type="text/javascript" src="' + src + '"></script>';
+      
+      var exclude = gMapConfig.exclude;
+      if (exclude) {
+        content = ''
+      }
     }
 
     return content;

--- a/index.js
+++ b/index.js
@@ -30,9 +30,6 @@ module.exports = {
       var client = gMapConfig.client;
       if (client) {
         params.push('client=' + encodeURIComponent(client));
-        if (!version) {
-          params.push('v=3');
-        }
       }
 
       var libraries = gMapConfig.libraries;


### PR DESCRIPTION
This PR adds a couple new config options for the Google Maps API script tag, plus the option to exclude the script tag from being added to the page by this addon. 

* Exclude: exclude config options allows an add-on consumer to exclude the google maps api script tag from the index.html. This is helpful in cases where another another ember addon is already including the library, or the google maps api library is otherwise already included on the page.

* Client: client config option is an alternative to the key parameter for applications that need to provide a client ID instead of an API key (Google Maps Premium Plan subscribers)

* Version: version config option allows an add-on consumer to ask for a specific version of the Google Maps API, rather than the default Release version.