### PR TITLE
Allow icons option on Polylines

### DIFF
--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ You can optionally set following custom polyline options as attributes:
 - `clickable`
 - `draggable`
 - `geodesic`
+- `icons`
 - `visible`
 
 ```handlebars

--- a/addon/components/g-map-polyline.js
+++ b/addon/components/g-map-polyline.js
@@ -5,7 +5,7 @@ import compact from '../utils/compact';
 
 const { isEmpty, isPresent, observer, computed, run, assert, typeOf } = Ember;
 
-const allowedPolylineOptions = Ember.A(['strokeColor', 'strokeWeight', 'strokeOpacity', 'zIndex', 'geodesic', 'clickable', 'draggable', 'visible']);
+const allowedPolylineOptions = Ember.A(['strokeColor', 'strokeWeight', 'strokeOpacity', 'zIndex', 'geodesic', 'icons', 'clickable', 'draggable', 'visible']);
 
 const GMapPolylineComponent = Ember.Component.extend({
   layout: layout,


### PR DESCRIPTION
The icons option allows for custom polyline styles, such as dashed or dotted lines.