### PR TITLE
Add path option for polyline

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ You can assign custom images to your markers by pointing the `icon` attribute to
 
 ### Complex Marker Icons
 
-You can also create a [complex marker icon](https://developers.google.com/maps/documentation/javascript/markers#complex_icons) by defining an icon object and passing it to the `icon` attribute 
+You can also create a [complex marker icon](https://developers.google.com/maps/documentation/javascript/markers#complex_icons) by defining an icon object and passing it to the `icon` attribute
 
 ```javascript
 myIcon: {
@@ -358,6 +358,7 @@ You can optionally set following custom polyline options as attributes:
 - `draggable`
 - `geodesic`
 - `visible`
+- `path`
 
 ```handlebars
 {{#g-map lat=37.7833 lng=-122.4167 zoom=12 as |context|}}
@@ -368,6 +369,8 @@ You can optionally set following custom polyline options as attributes:
     {{g-map-polyline-coordinate coordinateContext lat=37.7933 lng=-122.4567}}
     {{g-map-polyline-coordinate coordinateContext lat=37.7933 lng=-122.4667}}
   {{/g-map-polyline}}
+
+  {{g-map-polyline context path=decodedPolyline}}
 {{/g-map}}
 ```
 

--- a/README.md
+++ b/README.md
@@ -357,6 +357,7 @@ You can optionally set following custom polyline options as attributes:
 - `clickable`
 - `draggable`
 - `geodesic`
+- `icons`
 - `visible`
 - `path`
 

--- a/addon/components/g-map-polyline.js
+++ b/addon/components/g-map-polyline.js
@@ -84,7 +84,8 @@ const GMapPolylineComponent = Ember.Component.extend({
       let coordArray = Ember.A(this.get('coordinates').mapBy('coordinate')).compact();
       polyline.setPath(coordArray);
     }
-    else if (isPresent(polyline) && isPresent(path)) {
+    
+    if (isPresent(polyline) && isPresent(path)) {
       polyline.setPath(path);
     }
   },

--- a/addon/components/g-map-polyline.js
+++ b/addon/components/g-map-polyline.js
@@ -80,13 +80,17 @@ const GMapPolylineComponent = Ember.Component.extend({
     const coordinates = this.get('coordinates');
     const path = this.get('path');
 
-    if (isPresent(polyline) && isPresent(coordinates)) {
-      let coordArray = Ember.A(this.get('coordinates').mapBy('coordinate')).compact();
-      polyline.setPath(coordArray);
-    }
+    if (isPresent(polyline)) {
 
-    if (isPresent(polyline) && isPresent(path)) {
-      polyline.setPath(path);
+      if (isPresent(coordinates) && isEmpty(path)) {
+        let coordArray = Ember.A(this.get('coordinates').mapBy('coordinate')).compact();
+        polyline.setPath(coordArray);
+      }
+
+      if (isPresent(path) && isEmpty(coordinates)) {
+        polyline.setPath(path);
+      }
+
     }
   },
 

--- a/addon/components/g-map-polyline.js
+++ b/addon/components/g-map-polyline.js
@@ -5,7 +5,7 @@ import compact from '../utils/compact';
 
 const { isEmpty, isPresent, observer, computed, run, assert, typeOf } = Ember;
 
-const allowedPolylineOptions = Ember.A(['strokeColor', 'strokeWeight', 'strokeOpacity', 'zIndex', 'geodesic', 'clickable', 'draggable', 'visible']);
+const allowedPolylineOptions = Ember.A(['strokeColor', 'strokeWeight', 'strokeOpacity', 'zIndex', 'geodesic', 'clickable', 'draggable', 'visible', 'path']);
 
 const GMapPolylineComponent = Ember.Component.extend({
   layout: layout,
@@ -78,10 +78,14 @@ const GMapPolylineComponent = Ember.Component.extend({
   setPath() {
     const polyline = this.get('polyline');
     const coordinates = this.get('coordinates');
+    const path = this.get('path');
 
     if (isPresent(polyline) && isPresent(coordinates)) {
       let coordArray = Ember.A(this.get('coordinates').mapBy('coordinate')).compact();
       polyline.setPath(coordArray);
+    }
+    else if (isPresent(polyline) && isPresent(path)) {
+      polyline.setPath(path);
     }
   },
 

--- a/addon/components/g-map-polyline.js
+++ b/addon/components/g-map-polyline.js
@@ -84,7 +84,7 @@ const GMapPolylineComponent = Ember.Component.extend({
       let coordArray = Ember.A(this.get('coordinates').mapBy('coordinate')).compact();
       polyline.setPath(coordArray);
     }
-  
+
     if (isPresent(polyline) && isPresent(path)) {
       polyline.setPath(path);
     }

--- a/addon/components/g-map-polyline.js
+++ b/addon/components/g-map-polyline.js
@@ -84,7 +84,7 @@ const GMapPolylineComponent = Ember.Component.extend({
       let coordArray = Ember.A(this.get('coordinates').mapBy('coordinate')).compact();
       polyline.setPath(coordArray);
     }
-    
+  
     if (isPresent(polyline) && isPresent(path)) {
       polyline.setPath(path);
     }

--- a/addon/components/g-map-polyline.js
+++ b/addon/components/g-map-polyline.js
@@ -5,7 +5,7 @@ import compact from '../utils/compact';
 
 const { isEmpty, isPresent, observer, computed, run, assert, typeOf } = Ember;
 
-const allowedPolylineOptions = Ember.A(['strokeColor', 'strokeWeight', 'strokeOpacity', 'zIndex', 'geodesic', 'clickable', 'draggable', 'visible', 'path']);
+const allowedPolylineOptions = Ember.A(['strokeColor', 'strokeWeight', 'strokeOpacity', 'zIndex', 'geodesic', 'icons', 'clickable', 'draggable', 'visible', 'path']);
 
 const GMapPolylineComponent = Ember.Component.extend({
   layout: layout,


### PR DESCRIPTION
The pattern of polyline-coordinate-as-component was causing some performance issues for one of my use cases. In my case, I already have an encoded polyline being provided by my backend, so it makes sense to decode it and pass it directly as a path option to the google map polyline, rather than breaking each coordinate out into a separate component within an hbs each loop. This allows for a simple inline form of the polyline component if the path is already given (see Readme)