### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ In case you want to make the google map to have full width and height as the par
 
 ```css
 .g-map{
-  height:100%;
+  height: 100%;
 }
 .g-map-canvas {
-  width:100%;
+  width: 100%;
   height: 100%;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -93,11 +93,11 @@ You can also create a [complex marker icon](https://developers.google.com/maps/d
 ```javascript
 myIcon: {
   url: "/assets/images/driver-icon.svg",
-  size: new google.maps.size(30,30),
-  scaledSize: new google.maps.size(20,20),
-  anchor: new google.maps.point(15, 15),
-  origin: new google.maps.point(0, 0),
-  labelOrigin: new google.maps.point(30, 15),
+  size: new google.maps.Size(30,30),
+  scaledSize: new google.maps.Size(20,20),
+  anchor: new google.maps.Point(15, 15),
+  origin: new google.maps.Point(0, 0),
+  labelOrigin: new google.maps.Point(30, 15),
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ Simply add something similar to this to your styles:
   height: 400px;
 }
 ```
+In case you want to make the google map to have full width and height as the parent div, you can do the following:
+
+```css
+.g-map{
+  height:100%;
+}
+.g-map-canvas {
+  width:100%;
+  height: 100%;
+}
+```
 
 In `config/environment.js` you can specify:
 - additional Google Maps libraries to be loaded along with this add-on


### PR DESCRIPTION
Typo fixed in Complex marker.
See #74 for details. This change can prevent anyone from having `Uncaught TypeError: google.maps.size is not a constructor` bug.
