### PR TITLE
Fixing Enumerable#contains deprecation

### DIFF
--- a/addon/components/g-map-infowindow.js
+++ b/addon/components/g-map-infowindow.js
@@ -4,7 +4,7 @@ import GMapComponent from './g-map';
 import GMapMarkerComponent from './g-map-marker';
 import compact from '../utils/compact';
 
-const { isEmpty, isPresent, observer, computed, run, assert, typeOf } = Ember;
+const { isEmpty, isPresent, computed, run, assert, typeOf } = Ember;
 
 const allowedOptions = Ember.A(['disableAutoPan', 'maxWidth', 'pixelOffset']);
 
@@ -37,23 +37,22 @@ const GMapInfowindowComponent = Ember.Component.extend({
       const infowindow = this.buildInfowindow();
       this.set('infowindow', infowindow);
     }
-    this.setPosition();
-    this.setMap();
-    this.setMarker();
-    this.setOptions();
   },
 
-  willDestroyElement() {
-    this.close();
-
-    if (this.get('hasMarker')) {
-      this.get('mapContext').unregisterInfowindow();
+  didRender() {
+    this.setPosition();
+    this.setMap();
+    this.setOptions();
+    if (this.get('open')) {
+      this._open();
+    } else {
+      this._close();
     }
   },
 
-  optionsChanged: observer(...allowedOptions, function() {
-    run.once(this, 'setOptions');
-  }),
+  willDestroyElement() {
+    this._close();
+  },
 
   setOptions() {
     const infowindow = this.get('infowindow');
@@ -86,7 +85,7 @@ const GMapInfowindowComponent = Ember.Component.extend({
     }
   },
 
-  open() {
+  _open() {
     const infowindow = this.get('infowindow');
     const map = this.get('map');
     const marker = this.get('marker');
@@ -99,7 +98,7 @@ const GMapInfowindowComponent = Ember.Component.extend({
     }
   },
 
-  close() {
+  _close() {
     const infowindow = this.get('infowindow');
     if (isPresent(infowindow)) {
       this.set('isOpen', false);
@@ -107,36 +106,11 @@ const GMapInfowindowComponent = Ember.Component.extend({
     }
   },
 
-  mapWasSet: observer('map', function() {
-    run.once(this, 'setMap');
-  }),
-
   setMap() {
     if (this.get('hasMarker') === false) {
-      this.open();
+      this._open();
     }
   },
-
-  markerWasSet: observer('marker', function() {
-    run.once(this, 'setMarker');
-  }),
-
-  setMarker() {
-    const map = this.get('map');
-    const marker = this.get('marker');
-    const context = this.get('mapContext');
-    const infowindow = this.get('infowindow');
-
-    if (isPresent(infowindow) && isPresent(map) && isPresent(marker)) {
-      const openEvent = this.retrieveOpenEvent();
-      const closeEvent = this.retrieveCloseEvent();
-      context.registerInfowindow(this, openEvent, closeEvent);
-    }
-  },
-
-  coordsChanged: observer('lat', 'lng', function() {
-    run.once(this, 'setPosition');
-  }),
 
   setPosition() {
     const infowindow = this.get('infowindow');

--- a/addon/components/g-map-infowindow.js
+++ b/addon/components/g-map-infowindow.js
@@ -154,12 +154,12 @@ const GMapInfowindowComponent = Ember.Component.extend({
 
   retrieveOpenEvent() {
     const openEvent = this.get('openOn');
-    return OPEN_CLOSE_EVENTS.contains(openEvent) ? openEvent : 'click';
+    return OPEN_CLOSE_EVENTS.includes(openEvent) ? openEvent : 'click';
   },
 
   retrieveCloseEvent() {
     const closeEvent = this.get('closeOn');
-    return OPEN_CLOSE_EVENTS.contains(closeEvent) ? closeEvent : null;
+    return OPEN_CLOSE_EVENTS.includes(closeEvent) ? closeEvent : null;
   }
 });
 

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -21,7 +21,7 @@ export default Ember.Component.extend({
     const { options, bannedOptions } = this.getProperties(['options', 'bannedOptions']);
     const permittedOptions = {};
     for (let option in options) {
-      if (options.hasOwnProperty(option) && !bannedOptions.contains(option)) {
+      if (options.hasOwnProperty(option) && !bannedOptions.includes(option)) {
         permittedOptions[option] = options[option];
       }
     }
@@ -102,7 +102,7 @@ export default Ember.Component.extend({
   },
 
   shouldFit: computed('markersFitMode', function() {
-    return Ember.A(['init', 'live']).contains(this.get('markersFitMode'));
+    return Ember.A(['init', 'live']).includes(this.get('markersFitMode'));
   }),
 
   markersChanged: observer('markers.@each.lat', 'markers.@each.lng', function() {

--- a/package.json
+++ b/package.json
@@ -56,7 +56,8 @@
   ],
   "dependencies": {
     "ember-cli-babel": "^5.1.6",
-    "ember-cli-htmlbars": "^1.0.5"
+    "ember-cli-htmlbars": "^1.0.5",
+    "ember-runtime-enumerable-includes-polyfill": "^1.0.1"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
As documented in [the deprecation guide](http://emberjs.com/deprecations/v2.x/#toc_enumerable-contains), addons can use [this polyfill](https://github.com/rwjblue/ember-runtime-enumerable-includes-polyfill) to avoid the deprecation while still supporting older versions of Ember.

Closes #82 

(The test suite was already failing on beta and canary.)
