### PR TITLE
fix deprecation warning

### DIFF
--- a/addon/components/g-map-infowindow.js
+++ b/addon/components/g-map-infowindow.js
@@ -154,12 +154,12 @@ const GMapInfowindowComponent = Ember.Component.extend({
 
   retrieveOpenEvent() {
     const openEvent = this.get('openOn');
-    return OPEN_CLOSE_EVENTS.contains(openEvent) ? openEvent : 'click';
+    return OPEN_CLOSE_EVENTS.includes(openEvent) ? openEvent : 'click';
   },
 
   retrieveCloseEvent() {
     const closeEvent = this.get('closeOn');
-    return OPEN_CLOSE_EVENTS.contains(closeEvent) ? closeEvent : null;
+    return OPEN_CLOSE_EVENTS.includes(closeEvent) ? closeEvent : null;
   }
 });
 

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -21,7 +21,7 @@ export default Ember.Component.extend({
     const { options, bannedOptions } = this.getProperties(['options', 'bannedOptions']);
     const permittedOptions = {};
     for (let option in options) {
-      if (options.hasOwnProperty(option) && !bannedOptions.contains(option)) {
+      if (options.hasOwnProperty(option) && !bannedOptions.includes(option)) {
         permittedOptions[option] = options[option];
       }
     }
@@ -102,7 +102,7 @@ export default Ember.Component.extend({
   },
 
   shouldFit: computed('markersFitMode', function() {
-    return Ember.A(['init', 'live']).contains(this.get('markersFitMode'));
+    return Ember.A(['init', 'live']).includes(this.get('markersFitMode'));
   }),
 
   markersChanged: observer('markers.@each.lat', 'markers.@each.lng', function() {


### PR DESCRIPTION
- DEPRECATION: `Enumerable#contains` is deprecated, use `Enumerable#includes` instead. [deprecation id: ember-runtime.enumerable-contains] See http://emberjs.com/deprecations/v2.x#toc_enumerable-contains for more details.
