### PR TITLE
Remove importing css

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,11 +4,6 @@
 module.exports = {
   name: 'ember-g-map',
 
-  included: function(app, parentAddon) {
-    var target = (parentAddon || app);
-    target.import('vendor/addons.css');
-  },
-
   contentFor: function(type, config) {
     var content = '';
 


### PR DESCRIPTION
This is having unintended side effects.

If you want to import css into your dummy app you can do it in `ember-cli-build.js` that way it doesn't get pulled into whoever is consuming this addon.