### PR TITLE
typo in typeOf

### DIFF
--- a/addon/components/g-map-address-marker.js
+++ b/addon/components/g-map-address-marker.js
@@ -69,7 +69,7 @@ const GMapAddressMarkerComponent = Ember.Component.extend({
   sendOnLocationChange() {
     const { onLocationChange } = this.attrs;
 
-    if (typeOf(onLocationChange) === 'function') {
+    if (typeof(onLocationChange) === 'function') {
       onLocationChange(...arguments);
     } else {
       this.sendAction('onLocationChange', ...arguments);


### PR DESCRIPTION
typeOf is not available in JS, this is curious?