### PR TITLE
g-map-route expose calculated distance from service

### DIFF
--- a/addon/components/g-map-route.js
+++ b/addon/components/g-map-route.js
@@ -73,6 +73,7 @@ const GMapRouteComponent = Ember.Component.extend({
     run.once(this, 'updateRoute');
   }),
 
+  onUpdateRoute() {},
   updateRoute() {
     const service = this.get('directionsService');
     const renderer = this.get('directionsRenderer');
@@ -98,6 +99,7 @@ const GMapRouteComponent = Ember.Component.extend({
 
       service.route(request, (response, status) => {
         if (status === google.maps.DirectionsStatus.OK) {
+          this.get('onUpdateRoute')(response.routes[0].legs[0]);
           renderer.setDirections(response);
         }
       });

--- a/addon/components/g-map-route.js
+++ b/addon/components/g-map-route.js
@@ -73,7 +73,6 @@ const GMapRouteComponent = Ember.Component.extend({
     run.once(this, 'updateRoute');
   }),
 
-  onUpdateRoute() {},
   updateRoute() {
     const service = this.get('directionsService');
     const renderer = this.get('directionsRenderer');
@@ -99,7 +98,7 @@ const GMapRouteComponent = Ember.Component.extend({
 
       service.route(request, (response, status) => {
         if (status === google.maps.DirectionsStatus.OK) {
-          this.get('onUpdateRoute')(response.routes[0].legs[0]);
+          this.sendOnDirectionChange(response.routes[0].legs[0]);
           renderer.setDirections(response);
         }
       });
@@ -138,7 +137,17 @@ const GMapRouteComponent = Ember.Component.extend({
 
   waypointsChanged: observer('waypoints.@each.location', function() {
     run.once(this, 'updateRoute');
-  })
+  }),
+
+  sendOnDirectionChange() {
+    const { onDirectionChange } = this.attrs;
+
+    if (typeOf(onDirectionChange) === 'function') {
+      onDirectionChange(...arguments);
+    } else {
+      this.sendAction('onDirectionChange', ...arguments);
+    }
+  }
 });
 
 GMapRouteComponent.reopenClass({

--- a/addon/components/g-map-route.js
+++ b/addon/components/g-map-route.js
@@ -142,7 +142,7 @@ const GMapRouteComponent = Ember.Component.extend({
   sendOnDirectionChange() {
     const { onDirectionChange } = this.attrs;
 
-    if (typeOf(onDirectionChange) === 'function') {
+    if (typeof(onDirectionChange) === 'function') {
       onDirectionChange(...arguments);
     } else {
       this.sendAction('onDirectionChange', ...arguments);


### PR DESCRIPTION
When using g-map-route to display a route between two lat lng destinations.
If you want to show human readable information about distance and duration there is no chance to get that info.

We introduce a callback called: `onDistanceUpdate`
- the first leg of direction object will be exposed to the handler

