### PR TITLE
fix(infowindow): avoid calling set on destroyed object by removing from willDestroyElement hook

### DIFF
--- a/addon/components/g-map-infowindow.js
+++ b/addon/components/g-map-infowindow.js
@@ -115,7 +115,6 @@ const GMapInfowindowComponent = Ember.Component.extend({
   close() {
     const infowindow = this.get('infowindow');
     if (isPresent(infowindow)) {
-      this.set('isOpen', false);
       infowindow.close();
     }
   },


### PR DESCRIPTION
I was running into an issue where if I had an infowindow appearing over a marker but also had an `onClick` action on that marker that could remove the marker while the infowindow was visible I would get a "can not call set on a destroyed object" error during every map mousemove. This is the problematic `set` call, which should not be needed since the object we're setting a property on is just going to be destroyed anyways.