### PR TITLE
add typeof checks for google global

### DIFF
--- a/addon/components/g-map-infowindow.js
+++ b/addon/components/g-map-infowindow.js
@@ -65,7 +65,7 @@ const GMapInfowindowComponent = Ember.Component.extend({
   },
 
   buildInfowindow() {
-    if (google) {
+    if (typeof google !== 'undefined') {
       const infowindow = new google.maps.InfoWindow({
         content: this.get('element')
       });

--- a/addon/components/g-map-marker.js
+++ b/addon/components/g-map-marker.js
@@ -26,7 +26,8 @@ const GMapMarkerComponent = Ember.Component.extend({
   didInsertElement() {
     this._super(...arguments);
     if (isEmpty(this.get('marker'))
-      && (typeof FastBoot === 'undefined')) {
+      && (typeof FastBoot === 'undefined')
+      && (typeof google !== 'undefined')) {
       const marker = new google.maps.Marker();
       this.set('marker', marker);
     }

--- a/addon/components/g-map-polyline-coordinate.js
+++ b/addon/components/g-map-polyline-coordinate.js
@@ -22,7 +22,8 @@ const GMapPolylineCoordinateComponent = Ember.Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
-    if (isEmpty(this.get('coordinate'))) {
+    if (isEmpty(this.get('coordinate'))
+      && (typeof google !== 'undefined')) {
       const coordinate = new google.maps.LatLng();
       this.set('coordinate', coordinate);
     }
@@ -42,7 +43,10 @@ const GMapPolylineCoordinateComponent = Ember.Component.extend({
     const lat = this.get('lat');
     const lng = this.get('lng');
 
-    if (isPresent(polylineContext) && isPresent(lat) && isPresent(lng)) {
+    if (isPresent(polylineContext)
+      && isPresent(lat)
+      && isPresent(lng)
+      && (typeof google !== 'undefined')) {
       const coordinate = new google.maps.LatLng(lat, lng);
       this.set('coordinate', coordinate);
       polylineContext.setPath();

--- a/addon/components/g-map-polyline.js
+++ b/addon/components/g-map-polyline.js
@@ -29,7 +29,8 @@ const GMapPolylineComponent = Ember.Component.extend({
 
   didInsertElement() {
     this._super(...arguments);
-    if (isEmpty(this.get('polyline'))) {
+    if (isEmpty(this.get('polyline'))
+      && (typeof google !== 'undefined')) {
       const options = compact(this.getProperties(allowedPolylineOptions));
       const polyline = new google.maps.Polyline(options);
       this.set('polyline', polyline);

--- a/addon/components/g-map-route-address-waypoint.js
+++ b/addon/components/g-map-route-address-waypoint.js
@@ -20,7 +20,8 @@ const GMapRouteAddressWaypointComponent = Ember.Component.extend({
 
     if (isPresent(map)
       && isEmpty(service)
-      && (typeof FastBoot === 'undefined')) {
+      && (typeof FastBoot === 'undefined')
+      && (typeof google !== 'undefined')) {
       service = new google.maps.places.PlacesService(map);
       this.set('placesService', service);
 

--- a/addon/components/g-map-route-waypoint.js
+++ b/addon/components/g-map-route-waypoint.js
@@ -39,7 +39,8 @@ const GMapRouteWaypointComponent = Ember.Component.extend({
 
     if (isPresent(lat)
       && isPresent(lng)
-      && (typeof FastBoot === 'undefined')) {
+      && (typeof FastBoot === 'undefined')
+      && (typeof google !== 'undefined')) {
       let location = new google.maps.LatLng(lat, lng);
       this.set('waypoint', {
         location,

--- a/addon/components/g-map-route.js
+++ b/addon/components/g-map-route.js
@@ -52,7 +52,8 @@ const GMapRouteComponent = Ember.Component.extend({
     if (isPresent(map)
       && isEmpty(service)
       && isEmpty(renderer)
-      && (typeof FastBoot === 'undefined')) {
+      && (typeof FastBoot === 'undefined')
+      && (typeof google !== 'undefined')) {
       const rendererOptions = {
         map,
         suppressMarkers: true,

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -31,7 +31,8 @@ export default Ember.Component.extend({
   didInsertElement() {
     this._super(...arguments);
     if (isEmpty(this.get('map'))
-      && (typeof FastBoot === 'undefined')) {
+      && (typeof FastBoot === 'undefined')
+      && (typeof google !== 'undefined')) {
       const canvas = this.$().find('.g-map-canvas').get(0);
       const options = this.get('permittedOptions');
       this.set('map', new google.maps.Map(canvas, options));
@@ -79,7 +80,8 @@ export default Ember.Component.extend({
     if (isPresent(map)
       && isPresent(lat)
       && isPresent(lng)
-      && (typeof FastBoot === 'undefined')) {
+      && (typeof FastBoot === 'undefined')
+      && (typeof google !== 'undefined')) {
       const center = new google.maps.LatLng(lat, lng);
       map.setCenter(center);
     }


### PR DESCRIPTION
There are several places in the add on code base where the google global is used without first checking to make sure it is defined. This can lead to unhandled errors in production if, for whatever reason, the Google Maps API fails to load. 

It turns out that even a simple `if (google)...` check is insufficient since that will trigger a "google is undefined" error. The `if (typeof google !== 'undefined')` check prevents these unhandled errors.