### PR TITLE
Upgrade to Ember 3.4 LTS

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,18 @@
+# unconventional js
+/blueprints/*/files/
+/vendor/
+
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+
+# misc
+/coverage/
+
+# ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/package.json.ember-try

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,9 +27,11 @@ module.exports = {
     // node files
     {
       files: [
+        '.template-lintrc.js',
         'ember-cli-build.js',
         'index.js',
         'testem.js',
+        'blueprints/*/index.js',
         'config/**/*.js',
         'tests/dummy/config/**/*.js'
       ],

--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,8 @@
 # See http://help.github.com/ignore-files/ for more about ignoring files.
 
 # compiled output
-/dist
-/tmp
+/dist/
+/tmp/
 
 # dependencies
 /node_modules
@@ -12,17 +12,17 @@ package-lock.json
 # misc
 /.sass-cache
 /connect.lock
-/coverage/*
+/coverage/
 /libpeerconnection.log
-npm-debug.log*
-yarn-error.log
-testem.log
+/npm-debug.log*
+/testem.log
+/yarn-error.log
 
 # IDE misc
 /.idea
 jsconfig.json
 
 # ember-try
-.node_modules.ember-try/
-bower.json.ember-try
-package.json.ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/package.json.ember-try

--- a/.npmignore
+++ b/.npmignore
@@ -1,21 +1,28 @@
-/bower_components
+# compiled output
+/dist/
+/tmp/
+
+# dependencies
+/bower_components/
+
+# misc
+/.bowerrc
+/.editorconfig
+/.ember-cli
+/.eslintignore
+/.eslintrc.js
+/.gitignore
+/.watchmanconfig
+/.travis.yml
+/bower.json
 /config/ember-try.js
-/dist
-/tests
-/tmp
-**/.gitkeep
-.bowerrc
-.editorconfig
-.ember-cli
-.eslintrc.js
-.gitignore
-.watchmanconfig
-.travis.yml
-bower.json
-ember-cli-build.js
-testem.js
+/ember-cli-build.js
+/testem.js
+/tests/
+/yarn.lock
+.gitkeep
 
 # ember-try
-.node_modules.ember-try/
-bower.json.ember-try
-package.json.ember-try
+/.node_modules.ember-try/
+/bower.json.ember-try
+/package.json.ember-try

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+  extends: 'recommended'
+};

--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -1,5 +1,9 @@
 'use strict';
 
 module.exports = {
-  extends: 'recommended'
+  extends: 'recommended',
+
+  rules: {
+    'attribute-indentation': false,
+  }
 };

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: node_js
 node_js:
   # we recommend testing addons with the same minimum supported node version as Ember CLI
   # so that your addon works for all apps
-  - "4"
+  - "6"
 
 sudo: false
 dist: trusty
@@ -20,22 +20,31 @@ env:
   global:
     # See https://git.io/vdao3 for details.
     - JOBS=1
-  matrix:
+
+jobs:
+  fail_fast: true
+  allow_failures:
+    - env: EMBER_TRY_SCENARIO=ember-canary
+
+  include:
+    # runs linting and tests with current locked deps
+
+    - stage: "Tests"
+      name: "Tests"
+      script:
+        - npm run lint:hbs
+        - npm run lint:js
+        - npm test
+
     # we recommend new addons test the current and previous LTS
     # as well as latest stable release (bonus points to beta/canary)
-    - EMBER_TRY_SCENARIO=ember-lts-2.12
-    - EMBER_TRY_SCENARIO=ember-lts-2.16
-    - EMBER_TRY_SCENARIO=ember-lts-2.18
-    - EMBER_TRY_SCENARIO=ember-release
-    - EMBER_TRY_SCENARIO=ember-beta
-    - EMBER_TRY_SCENARIO=ember-canary
-    - EMBER_TRY_SCENARIO=ember-default
-
-matrix:
-  fast_finish: true
-  allow_failures:
+    - stage: "Additional Tests"
+      env: EMBER_TRY_SCENARIO=ember-lts-2.16
+    - env: EMBER_TRY_SCENARIO=ember-lts-2.18
+    - env: EMBER_TRY_SCENARIO=ember-release
     - env: EMBER_TRY_SCENARIO=ember-beta
     - env: EMBER_TRY_SCENARIO=ember-canary
+    - env: EMBER_TRY_SCENARIO=ember-default-with-jquery
 
 before_install:
   - npm config set spin false

--- a/README.md
+++ b/README.md
@@ -421,6 +421,7 @@ http://asennikov.github.io/ember-g-map/
 
 ### Linting
 
+* `npm run lint:hbs`
 * `npm run lint:js`
 * `npm run lint:js -- --fix`
 

--- a/addon/components/g-map.js
+++ b/addon/components/g-map.js
@@ -139,7 +139,7 @@ export default Component.extend({
   },
 
   groupMarkerClicked(marker, group) {
-    let markers = this.get('markers').without(marker).filterBy('group', group);
+    let markers = A(this.get('markers').without(marker)).filterBy('group', group);
     markers.forEach((marker) => marker.closeInfowindow());
   }
 });

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -11,25 +11,25 @@ module.exports = function() {
     return {
       scenarios: [
         {
-          name: 'ember-lts-2.12',
-          npm: {
-            devDependencies: {
-              'ember-source': '~2.12.0'
-            }
-          }
-        },
-        {
           name: 'ember-lts-2.16',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+          },
           npm: {
             devDependencies: {
+              '@ember/jquery': '^0.5.1',
               'ember-source': '~2.16.0'
             }
           }
         },
         {
           name: 'ember-lts-2.18',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+          },
           npm: {
             devDependencies: {
+              '@ember/jquery': '^0.5.1',
               'ember-source': '~2.18.0'
             }
           }
@@ -62,6 +62,19 @@ module.exports = function() {
           name: 'ember-default',
           npm: {
             devDependencies: {}
+          }
+        },
+        {
+          name: 'ember-default-with-jquery',
+          env: {
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({
+              'jquery-integration': true
+            })
+          },
+          npm: {
+            devDependencies: {
+              '@ember/jquery': '^0.5.1'
+            }
           }
         }
       ]

--- a/config/ember-try.js
+++ b/config/ember-try.js
@@ -13,7 +13,7 @@ module.exports = function() {
         {
           name: 'ember-lts-2.16',
           env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true })
           },
           npm: {
             devDependencies: {
@@ -25,7 +25,7 @@ module.exports = function() {
         {
           name: 'ember-lts-2.18',
           env: {
-            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true }),
+            EMBER_OPTIONAL_FEATURES: JSON.stringify({ 'jquery-integration': true })
           },
           npm: {
             devDependencies: {

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-g-map',
+  name: require('./package').name,
 
   contentFor(type, config) {
     let content = '';

--- a/package.json
+++ b/package.json
@@ -2,59 +2,55 @@
   "name": "ember-g-map",
   "version": "0.0.25",
   "description": "An ember-cli addon for integration with google maps.",
-  "directories": {
-    "doc": "doc",
-    "test": "tests"
-  },
   "scripts": {
     "build": "ember build",
-    "lint:js": "eslint ./*.js addon addon-test-support app config lib server test-support tests",
+    "lint:hbs": "ember-template-lint .",
+    "lint:js": "eslint .",
     "start": "ember serve",
     "test": "ember test",
     "test:all": "ember try:each"
   },
-  "repository": "https://github.com/asennikov/ember-g-map",
   "engines": {
-    "node": "^4.5 || 6.* || >= 7.*"
+    "node": "6.* || 8.* || >= 10.*"
   },
-  "author": "Alexander Sennikov (gseno88@gmail.com)",
-  "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "^2.4.5",
+    "@ember/optional-features": "^0.6.3",
+    "broccoli-asset-rev": "^2.7.0",
     "coveralls": "^2.11.4",
-    "ember-ajax": "^3.0.0",
-    "ember-cli": "~3.1.2",
+    "ember-ajax": "^3.1.0",
+    "ember-cli": "~3.4.3",
     "ember-cli-app-version": "^3.1.3",
     "ember-cli-code-coverage": "^0.4.2",
-    "ember-cli-dependency-checker": "^2.1.0",
+    "ember-cli-dependency-checker": "^3.0.0",
     "ember-cli-eslint": "^4.2.3",
     "ember-cli-github-pages": "0.0.6",
-    "ember-cli-htmlbars-inline-precompile": "^1.0.0",
-    "ember-cli-inject-live-reload": "^1.4.1",
-    "ember-cli-qunit": "^4.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^1.0.3",
+    "ember-cli-inject-live-reload": "^1.8.2",
+    "ember-cli-qunit": "^4.3.2",
     "ember-cli-release": "0.2.9",
-    "ember-cli-shims": "^1.2.0",
-    "ember-cli-sri": "^2.1.0",
+    "ember-cli-sri": "^2.1.1",
+    "ember-cli-template-lint": "^1.0.0-beta.1",
     "ember-cli-test-loader": "^2.1.0",
-    "ember-cli-uglify": "^2.0.0",
+    "ember-cli-uglify": "^2.1.0",
     "ember-cli-update": "^0.21.2",
     "ember-data": "^2.6.0",
-    "ember-disable-prototype-extensions": "^1.1.2",
+    "ember-disable-prototype-extensions": "^1.1.3",
     "ember-export-application-global": "^2.0.0",
     "ember-factory-for-polyfill": "^1.1.1",
-    "ember-load-initializers": "^1.0.0",
+    "ember-load-initializers": "^1.1.0",
     "ember-maybe-import-regenerator": "^0.1.6",
-    "ember-resolver": "^4.0.0",
+    "ember-resolver": "^5.0.1",
     "ember-runtime-enumerable-includes-polyfill": "2.1.0",
     "ember-sinon": "2.1.0",
     "ember-sinon-qunit": "3.1.0",
-    "ember-source": "~3.1.0",
-    "ember-source-channel-url": "^1.0.1",
-    "ember-try": "^0.2.23",
-    "eslint-plugin-ember": "^5.0.0",
+    "ember-source": "~3.4.0",
+    "ember-source-channel-url": "^1.1.0",
+    "ember-try": "^1.0.0",
+    "eslint-plugin-ember": "^5.2.0",
     "eslint-plugin-ember-suave": "^1.0.0",
-    "eslint-plugin-node": "^6.0.1",
-    "loader.js": "^4.2.3"
+    "eslint-plugin-node": "^7.0.1",
+    "loader.js": "^4.7.0",
+    "qunit-dom": "^0.7.1"
   },
   "keywords": [
     "ember-addon",
@@ -65,9 +61,16 @@
     "map",
     "maps"
   ],
+  "repository": "https://github.com/asennikov/ember-g-map",
+  "license": "MIT",
+  "author": "Alexander Sennikov (gseno88@gmail.com)",
+  "directories": {
+    "doc": "doc",
+    "test": "tests"
+  },
   "dependencies": {
-    "ember-cli-babel": "^6.12.0",
-    "ember-cli-htmlbars": "^2.0.1"
+    "ember-cli-babel": "^6.16.0",
+    "ember-cli-htmlbars": "^3.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/testem.js
+++ b/testem.js
@@ -7,15 +7,16 @@ module.exports = {
   'launch_in_dev': [
     'Chrome'
   ],
-  'browser_args': {
-    'Chrome': {
-      'mode': 'ci',
-      'args': [
+  browser_args: {
+    Chrome: {
+      ci: [
         // --no-sandbox is needed when running Chrome inside a container
-        process.env.TRAVIS ? '--no-sandbox' : null,
-
-        '--disable-gpu',
+        process.env.CI ? '--no-sandbox' : null,
         '--headless',
+        '--disable-gpu',
+        '--disable-dev-shm-usage',
+        '--disable-software-rasterizer',
+        '--mute-audio',
         '--remote-debugging-port=0',
         '--window-size=1440,900'
       ].filter(Boolean)

--- a/testem.js
+++ b/testem.js
@@ -7,7 +7,7 @@ module.exports = {
   'launch_in_dev': [
     'Chrome'
   ],
-  browser_args: {
+  'browser_args': {
     Chrome: {
       ci: [
         // --no-sandbox is needed when running Chrome inside a container

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,3 +1,3 @@
 {
-  "jquery-integration": false
+  "jquery-integration": true
 }

--- a/tests/dummy/config/optional-features.json
+++ b/tests/dummy/config/optional-features.json
@@ -1,0 +1,3 @@
+{
+  "jquery-integration": false
+}


### PR DESCRIPTION
Updates the addon to be Ember 3.4 compatible. I had to disable the "attribute-indentation" rule for the template linter in the interest of keeping the templates as they are.